### PR TITLE
Capistranoを利用したデプロイの設定修正

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -14,6 +14,7 @@ require 'capistrano/bundler'
 require 'capistrano/rails/assets'
 require 'capistrano/rails/migrations'
 require 'capistrano3/unicorn'
+require 'capistrano/rails/console'
 
 # Load custom tasks from `lib/capistrano/tasks` if you have any defined
 Dir.glob("lib/capistrano/tasks/*.rake").each { |r| import r }

--- a/Gemfile
+++ b/Gemfile
@@ -45,6 +45,7 @@ group :development, :test do
   gem 'capistrano-bundler'
   gem 'capistrano-rails'
   gem 'capistrano3-unicorn'
+  gem 'capistrano-rails-console'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,9 @@ GEM
     capistrano-rails (1.4.0)
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
+    capistrano-rails-console (2.3.0)
+      capistrano (>= 3.5.0, < 4.0.0)
+      sshkit-interactive (~> 0.3.0)
     capistrano-rbenv (2.1.4)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
@@ -277,6 +280,8 @@ GEM
     sshkit (1.19.1)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    sshkit-interactive (0.3.0)
+      sshkit (~> 1.12)
     temple (0.8.1)
     thor (0.20.3)
     thread_safe (0.3.6)
@@ -314,6 +319,7 @@ DEPENDENCIES
   capistrano
   capistrano-bundler
   capistrano-rails
+  capistrano-rails-console
   capistrano-rbenv
   capistrano3-unicorn
   capybara (>= 2.15)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -5,7 +5,7 @@ set :application, "freemarket_sample_50a"
 set :repo_url, "git@github.com:seimangorira/freemarket_sample_50a.git"
 
 # Default branch is :master
-# ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
+ask :branch, `git rev-parse --abbrev-ref HEAD`.chomp
 
 # Default deploy_to directory is /var/www/my_app_name
 # set :deploy_to, "/var/www/my_app_name"

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -58,7 +58,8 @@ set :keep_releases, 5
 after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :restart do
-    invoke 'unicorn:restart'
+    invoke 'unicorn:stop'
+    invoke 'unicorn:start'
   end
 
   desc 'upload secrets.yml'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -74,12 +74,3 @@ namespace :deploy do
   before :starting, 'deploy:upload'
   after :finishing, 'deploy:cleanup'
 end
-
-set :default_env, {
-  rbenv_root: "/usr/local/rbenv",
-  path: "/usr/local/rbenv/shims:/usr/local/rbenv/bin:$PATH",
-  AWS_ACCESS_KEY_ID: ENV["AWS_ACCESS_KEY_ID"],
-  AWS_SECRET_ACCESS_KEY: ENV["AWS_SECRET_ACCESS_KEY"],
-  BASIC_AUTH_USER: ENV["BASIC_AUTH_USER"],
-  BASIC_AUTH_PASSWORD: ENV["BASIC_AUTH_PASSWORD"]
-}


### PR DESCRIPTION
# What
1. Capistranoでのデプロイ時に使用するローカルの環境変数を削除し、環境変数を本番環境にまとめた。
   本番環境では、~/.bash_profileに記載していた環境変数を、/etc/environmentに移した。
2. Capistranoを経由してデプロイする際の、Unicornのrestartタスクの内容を、「停止→起動」に修正した。
 
# Why
1.  起動方法によって読み込まれる環境変数が異なってしまうリスクを未然に防ぐため。
2. Capistranoでのデプロイ時に、環境変数等の更新を正しく反映させるため。
    完全にサーバーがダウンする時間が一部発生するが、一般ユーザーに開放するものではないため、問題ないと判断した。
