### PR TITLE
ActiveHashのインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,3 +80,4 @@ gem 'fog-aws'
 gem 'devise'
 gem 'jquery-rails'
 gem "recaptcha"
+gem 'active_hash'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,8 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_hash (2.2.1)
+      activesupport (>= 5.0.0)
     activejob (5.2.3)
       activesupport (= 5.2.3)
       globalid (>= 0.3.6)
@@ -314,6 +316,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_hash
   bootsnap (>= 1.1.0)
   byebug
   capistrano


### PR DESCRIPTION
# What 
ActiveHash（Gem）を導入した。

# Why
サービスで使用する都道府県などの静的データを、モデルを使用せずに管理するため。
都道府県データについては、別のブランチで実装します。

#### 参考サイト
- https://github.com/zilkey/active_hash
- https://kossy-web-engineer.hatenablog.com/entry/2019/01/08/205702