### PR TITLE
商品出品機能の作成

### DIFF
--- a/app/assets/stylesheets/items/_new_item.scss
+++ b/app/assets/stylesheets/items/_new_item.scss
@@ -81,10 +81,9 @@
             position: relative;
             transition: box-shadow ease-out .3s;
             width: 100%;
-            input {
-              border: 0;
-              outline: 0;
+            &--input {
               touch-action: manipulation;
+              display: none;
             }
             pre {
               display: block;

--- a/app/assets/stylesheets/items/_new_item.scss
+++ b/app/assets/stylesheets/items/_new_item.scss
@@ -32,6 +32,10 @@
       .form-require {
         @include formRequire;
       }
+      .form-arbitrary {
+        @include formRequire;
+        background: #ccc;
+      }
       .form-group {
         margin: 40px 0 0;
       }

--- a/app/assets/stylesheets/items/_new_item.scss
+++ b/app/assets/stylesheets/items/_new_item.scss
@@ -191,6 +191,9 @@
       }
       .confirmation-box {
         // width: 100%;
+        a {
+          text-decoration: none;
+        }
         p {
           line-height: 1.5;
         }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,6 +7,8 @@ class ItemsController < ApplicationController
   end
   
   def new
+    @item = Item.new
+    @parent_categories = Category.where(ancestry: nil)
   end
 
   def create

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,6 +9,9 @@ class ItemsController < ApplicationController
   def new
   end
 
+  def create
+  end
+
   def buy
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -9,11 +9,29 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @parent_categories = Category.where(ancestry: nil)
+
+    # 以下は仮実装のため、カテゴリーフォームを動的に作成する際に変更します。
+    @child_categories = Category.where(ancestry: 1)
+    @grandchild_categories = Category.find(14).children
   end
 
   def create
+    @item = Item.new(item_params)
+    if @item.save 
+      redirect_to root_path
+    else
+      render :new
+    end
   end
 
   def buy
+  end
+
+  private
+  # salar_idは、ユーザー登録機能の完成後、current_user.idに修正
+  def item_params
+    params.require(:item).permit(
+      :name, :introduction, :category_id, :size, :brand, :state, :delivery_fee, :delivery_method, :city, :delivery_days, :price, images: []
+    ).merge(saler_id: User.find(1).id, status: 1)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,9 @@ class Item < ApplicationRecord
   belongs_to :category
   has_many_attached :images
 
+  extend ActiveHash::Associations::ActiveRecordExtensions  
+  belongs_to_active_hash :prefecture
+
   belongs_to :saler, class_name: "User"
-  belongs_to :buyer, class_name: "User"
+  belongs_to :buyer, class_name: "User", optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,6 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :items
   has_many :comments
   has_one :credit
   has_many :buyer_items, foreign_key: "buyer_id", class_name: "Item"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :comments
   has_one :credit
-  has_many :buyer_items, foreign_key: "buyer_id", class_name: "Item"
+  has_many :buyed_items, foreign_key: "buyer_id", class_name: "Item"
   has_many :saling_items, -> { where("buyer_id is NULL")}, foreign_key: "salier_id", class_name: "Item"
   has_many :sold_items, -> { where("buyer_id is NULL")}, foreign_key: "salier_id", class_name: "Item"
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -15,10 +15,10 @@
                 必須
             .upload-images__addition
               最大10枚までアップロードできます
-            .upload-images__container
+            = f.label :image, class: "upload-images__container" do
               -# TODO:jQueryで複数枚アップロード機能実装？(have-itemに変数でNoを設定)
               .upload-images__container__box.have-item
-                %input.upload-images__container__box--drop-file{type: "file", name: "image", style: "display: none;", multiple: true}
+                = f.file_field :image, class: "upload-images__container__box--input"
                 %pre.input.upload-images__container--text
                   ドラッグアンドドロップ
                   またはクリックしてファイルをアップロード

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -114,7 +114,8 @@
                     必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  = f.select :delivery_days, [["1~2日で発送", 1], ["2~3日で発送", 2], ["4~7日で発送", 3]], {prompt: "---"}, {class: "select-wrap__input"}
+                  -# 現状、カラムの型が「date」になっているため、修正の必要あり。出品機能の実装のため、仮でDate.todayと設定。
+                  = f.select :delivery_days, [["1~2日で発送", Date.today], ["2~3日で発送", Date.today], ["4~7日で発送", Date.today]], {prompt: "---"}, {class: "select-wrap__input"}
 
           .container__form__content.selling-item.clearfix
             .selling-item__title.form-sub-title

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -35,7 +35,7 @@
                 商品の説明
                 %span.form-require 
                   必須
-              %textarea.item-about__description--input{placeholder: "商品の説明（必須1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"}
+              = f.text_area :introduction, class: "item-about__description--input", placeholder: "商品の説明（必須1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"
           
           .container__form__content.item-detail.clearfix
             .item-detail__title.form-sub-title 商品の詳細

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -82,7 +82,16 @@
                 .select-wrap
                   %i.fas.fa-angle-down
                   = f.select :delivery_fee, [["送料込み(出品者負担)", 1], ["着払い(購入者負担)", 2]], {prompt: "---"}, {class: "select-wrap__input"}
-                  
+              
+              .form-group
+                %label.delivery-setting__burden
+                  配送の方法
+                  %span.form-require 
+                    必須
+                .select-wrap
+                  %i.fas.fa-angle-down
+                  = f.select :delivery_method, [["未定", 1], ["らくらくメルカリ便", 2], ["ゆうメール", 3], ["レターパック", 4], ["普通郵便(定形、定形外)", 5], ["クロネコヤマト", 6], ["ゆうパック", 7], ["クリックポスト", 8], ["ゆうパケット", 9]], {prompt: "---"}, {class: "select-wrap__input"}
+
               .form-group
                 %label.delivery-setting__region
                   発送元の地域

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -15,10 +15,10 @@
                 必須
             .upload-images__addition
               最大10枚までアップロードできます
-            = f.label :image, class: "upload-images__container" do
+            = f.label :images, class: "upload-images__container" do
               -# TODO:jQueryで複数枚アップロード機能実装？(have-itemに変数でNoを設定)
               .upload-images__container__box.have-item
-                = f.file_field :image, class: "upload-images__container__box--input"
+                = f.file_field :images, multiple: true, class: "upload-images__container__box--input"
                 %pre.input.upload-images__container--text
                   ドラッグアンドドロップ
                   またはクリックしてファイルをアップロード

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -29,7 +29,7 @@
                 商品名
                 %span.form-require 
                   必須
-              %input.item-about__name--input{type: "text", placeholder: "商品名（必須 40文字まで)"}
+              = f.text_field :name, class: "item-about__name--input", placeholder: "商品名（必須 40文字まで)"
             .form-group
               %label.item-about__description 
                 商品の説明

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -65,10 +65,8 @@
                     必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  %select.select-wrap__input
-                    %option{value: ""} ---
-                    %option{value: "1"} 送料込み(出品者負担)
-                    %option{value: "2"} 着払い(購入者負担)
+                  = f.select :delivery_fee, [["送料込み(出品者負担)", 1], ["着払い(購入者負担)", 2]], {prompt: "---"}, {class: "select-wrap__input"}
+                  
               .form-group
                 %label.delivery-setting__region
                   発送元の地域

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -97,10 +97,7 @@
                     必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  %select.select-wrap__input
-                    %option{value: ""} ---
-                    - Prefecture.all.each do |ele|
-                      %option{value: ele.name}= ele.name
+                  = f.collection_select :city, Prefecture.all, :id, :name, {prompt: "---"}, {class: "select-wrap__input"}
 
               .form-group
                 %label.delivery-setting__days

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -46,7 +46,16 @@
                   %span.form-require 必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  = f.collection_select :p_category_id, Category.where("id < ?", 14), :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.collection_select :p_category_id, @parent_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
+
+                .form-group
+                  %label.item-detail__category 
+                    サイズ
+                    %span.form-require 必須
+                  .select-wrap
+                    %i.fas.fa-angle-down
+                    = f.select :size, [["XXS以下", "XXS以下"], ["XS(SS)", "XS(SS)"],["S","S"],["M","M"],["L","L"],["XL(LL)","XL(LL)"],["2XL(3L)","2XL(3L)"],["3XL(4L)","3XL(4L)"],["4XL(5L以上)","4XL(5L以上)"],["FREE SIZE","FREE SIZE"]], {prompt: "---"} , class:"select-wrap__input"
+
               .form-group
                 %label.item-detail__state 
                   商品の状態

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -46,7 +46,13 @@
                   %span.form-require 必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  = f.collection_select :p_category_id, @parent_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.collection_select :category_id, @parent_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
+                .select-wrap
+                  %i.fas.fa-angle-down
+                  = f.collection_select :category_id, @child_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
+                .select-wrap
+                  %i.fas.fa-angle-down
+                  = f.collection_select :category_id, @grandchild_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
 
                 .form-group
                   %label.item-detail__category 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -56,6 +56,13 @@
                     %i.fas.fa-angle-down
                     = f.select :size, [["XXS以下", "XXS以下"], ["XS(SS)", "XS(SS)"],["S","S"],["M","M"],["L","L"],["XL(LL)","XL(LL)"],["2XL(3L)","2XL(3L)"],["3XL(4L)","3XL(4L)"],["4XL(5L以上)","4XL(5L以上)"],["FREE SIZE","FREE SIZE"]], {prompt: "---"} , class:"select-wrap__input"
 
+                .form-group
+                  %label.item-detail__category 
+                    ブランド
+                    %span.form-arbitrary 任意
+                  .select-wrap
+                    = f.text_field :brand, class:"select-wrap__input", placeholder: "例）シャネル"
+
               .form-group
                 %label.item-detail__state 
                   商品の状態

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -60,7 +60,7 @@
                     %span.form-require 必須
                   .select-wrap
                     %i.fas.fa-angle-down
-                    = f.select :size, [["XXS以下", "XXS以下"], ["XS(SS)", "XS(SS)"],["S","S"],["M","M"],["L","L"],["XL(LL)","XL(LL)"],["2XL(3L)","2XL(3L)"],["3XL(4L)","3XL(4L)"],["4XL(5L以上)","4XL(5L以上)"],["FREE SIZE","FREE SIZE"]], {prompt: "---"} , class:"select-wrap__input"
+                    = f.select :size, [["XXS以下", 0], ["XS(SS)", 1],["S",2],["M",3],["L", 4],["XL(LL)",5],["2XL(3L)", 6],["3XL(4L)", 7],["4XL(5L以上)", 8],["FREE SIZE", 9]], {prompt: "---"} , class:"select-wrap__input"
 
                 .form-group
                   %label.item-detail__category 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -137,28 +137,27 @@
                 %p.selling-item__profit--title 販売利益
                 %p.selling-item__profit--result -
         
-        .container__form__content.confirmation-box.clearfix
-          .confirmation-box__description
-            %p<>
-              = link_to "禁止されている出品", "#"
-              、
-              = link_to "行為", "#"
-              を必ずご確認ください。
-            %p<>
-              またブランド品でシリアルナンバー等がある場合はご記載ください。
-              = link_to "偽ブランドの販売", "#"
-              は犯罪であり処罰される可能性があります。
-            %p<> 
-              また、出品をもちまして
-              = link_to "加盟店規約", "#"
-              に同意したことになります。
-          .confirmation-box__btn
-            .confirmation-box__btn--exhibition
-              -# TODO:form_forで修正時に、submitで置き換え？
-              = button_to '出品する', root_path, method: :get, class: "btn btn-red"
-            .confirmation-box__btn--back
-              -# TODO:仮でroot_pathに設定。後日、ユーザーマイページへリンクを書き換える必要あり
-              = button_to 'もどる', root_path, method: :get, class: "btn btn-gray"
+          .container__form__content.confirmation-box.clearfix
+            .confirmation-box__description
+              %p<>
+                = link_to "禁止されている出品", "#"
+                、
+                = link_to "行為", "#"
+                を必ずご確認ください。
+              %p<>
+                またブランド品でシリアルナンバー等がある場合はご記載ください。
+                = link_to "偽ブランドの販売", "#"
+                は犯罪であり処罰される可能性があります。
+              %p<> 
+                また、出品をもちまして
+                = link_to "加盟店規約", "#"
+                に同意したことになります。
+            .confirmation-box__btn
+              .confirmation-box__btn--exhibition
+                = f.submit "出品する", class: "confirmation-box__btn--exhibition btn btn-red"
+              .confirmation-box__btn--back
+                -# TODO:仮でroot_pathに設定。ユーザー登録機能の実装後、ユーザーマイページへリンクを書き換える必要あり
+                = link_to 'もどる', root_path, class: "confirmation-box__btn--back btn btn-gray"
 
   %footer.new-item-page__footer
     %nav.new-item-page__footer__nav

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -52,7 +52,7 @@
                   = f.collection_select :category_id, @child_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
                 .select-wrap
                   %i.fas.fa-angle-down
-                  = f.collection_select :category_id, @grandchild_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.collection_select :category_id, @grandchild_categories, :id, :name, {prompt: "---"}, {class: "select-wrap__input"}
 
                 .form-group
                   %label.item-detail__category 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -5,136 +5,136 @@
     %section.container
       %h2.container__head
         .container__head__title 商品の情報を入力
-      -# Itemモデル作成後、form_for or form_withで実装
-
-      .container__form
-        .container__form__content.upload-images
-          %label.upload-images__label
-            出品画像
-            %span.form-require 
-              必須
-          .upload-images__addition
-            最大10枚までアップロードできます
-          .upload-images__container
-            -# TODO:jQueryで複数枚アップロード機能実装？(have-itemに変数でNoを設定)
-            .upload-images__container__box.have-item
-              %input.upload-images__container__box--drop-file{type: "file", name: "image", style: "display: none;", multiple: true}
-              %pre.input.upload-images__container--text
-                ドラッグアンドドロップ
-                またはクリックしてファイルをアップロード
-
-        .container__form__content.item-about.clearfix
-          .form-group
-            %label.item-about__name 
-              商品名
+      
+      = form_with model: @item, local: true do |f|
+        .container__form
+          .container__form__content.upload-images
+            %label.upload-images__label
+              出品画像
               %span.form-require 
                 必須
-            %input.item-about__name--input{type: "text", placeholder: "商品名（必須 40文字まで)"}
-          .form-group
-            %label.item-about__description 
-              商品の説明
-              %span.form-require 
-                必須
-            %textarea.item-about__description--input{placeholder: "商品の説明（必須1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"}
-        
-        .container__form__content.item-detail.clearfix
-          .item-detail__title.form-sub-title 商品の詳細
-          .item-detail__right-box.form-right-box
-            .form-group
-              %label.item-detail__category 
-                カテゴリー
-                %span.form-require 必須
-              .select-wrap
-                %i.fas.fa-angle-down
-                %select.select-wrap__input
-                  %option{value: ""} ---
-                  %option{value: "1"} レディース
-                  %option{value: "2"} メンズ
-                  %option{value: "3"} ベビー・キッズ
-                  %option{value: "4"} インテリア・住まい・小物
-                  %option{value: "5"} 本・音楽・ゲーム
-                  %option{value: "6"} おもちゃ・ホビー・グッズ
-                  %option{value: "7"} コスメ・香水・美容
-                  %option{value: "8"} 家電・スマホ・カメラ
-                  %option{value: "9"} スポーツ・レビュー
-                  %option{value: "10"} ハンドメイド
-                  %option{value: "11"} チケット
-                  %option{value: "12"} 自動車・オートバイ
-                  %option{value: "13"} その他
-            .form-group
-              %label.item-detail__state 
-                商品の状態
-                %span.form-require 必須
-              .select-wrap
-                %i.fas.fa-angle-down
-                %select.select-wrap__input
-                  %option{value: ""} ---
-                  %option{value: "1"} 新品、未使用
-                  %option{value: "2"} 未使用に近い
-                  %option{value: "3"} 目立った傷や汚れなし
-                  %option{value: "4"} やや傷や汚れあり
-                  %option{value: "5"} 傷や汚れあり
-                  %option{value: "6"} 全体的に状態が悪い
-        
-        .container__form__content.delivery-setting.clearfix
-          .delivery-setting__title.form-sub-title 配送について
-          .delivery-setting__rightbox.form-right-box
-            .form-group
-              %label.delivery-setting__burden
-                配送料の負担
-                %span.form-require 
-                  必須
-              .select-wrap
-                %i.fas.fa-angle-down
-                %select.select-wrap__input
-                  %option{value: ""} ---
-                  %option{value: "1"} 送料込み(出品者負担)
-                  %option{value: "2"} 着払い(購入者負担)
-            .form-group
-              %label.delivery-setting__region
-                発送元の地域
-                %span.form-require 
-                  必須
-              .select-wrap
-                %i.fas.fa-angle-down
-                %select.select-wrap__input
-                  %option{value: ""} ---
-                  - Prefecture.all.each do |ele|
-                    %option{value: ele.name}= ele.name
+            .upload-images__addition
+              最大10枚までアップロードできます
+            .upload-images__container
+              -# TODO:jQueryで複数枚アップロード機能実装？(have-itemに変数でNoを設定)
+              .upload-images__container__box.have-item
+                %input.upload-images__container__box--drop-file{type: "file", name: "image", style: "display: none;", multiple: true}
+                %pre.input.upload-images__container--text
+                  ドラッグアンドドロップ
+                  またはクリックしてファイルをアップロード
 
+          .container__form__content.item-about.clearfix
             .form-group
-              %label.delivery-setting__days
-                発送までの日数
+              %label.item-about__name 
+                商品名
                 %span.form-require 
                   必須
-              .select-wrap
-                %i.fas.fa-angle-down
-                %select.select-wrap__input
-                  %option{value: ""} ---
-                  %option{value: "1"} 1~2日で発送
-                  %option{value: "2"} 2~3日で発送
-                  %option{value: "3"} 4~7日で発送
-
-        .container__form__content.selling-item.clearfix
-          .selling-item__title.form-sub-title
-            販売価格(300〜9,999,999)
-          %ul.selling-item__right-box.form-right-box
-            %li.form-group.selling-item__price
-              .selling-item__price__inner-left
-                %label.selling-item__price--setting
-                  価格
+              %input.item-about__name--input{type: "text", placeholder: "商品名（必須 40文字まで)"}
+            .form-group
+              %label.item-about__description 
+                商品の説明
+                %span.form-require 
+                  必須
+              %textarea.item-about__description--input{placeholder: "商品の説明（必須1,000文字以内）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"}
+          
+          .container__form__content.item-detail.clearfix
+            .item-detail__title.form-sub-title 商品の詳細
+            .item-detail__right-box.form-right-box
+              .form-group
+                %label.item-detail__category 
+                  カテゴリー
+                  %span.form-require 必須
+                .select-wrap
+                  %i.fas.fa-angle-down
+                  %select.select-wrap__input
+                    %option{value: ""} ---
+                    %option{value: "1"} レディース
+                    %option{value: "2"} メンズ
+                    %option{value: "3"} ベビー・キッズ
+                    %option{value: "4"} インテリア・住まい・小物
+                    %option{value: "5"} 本・音楽・ゲーム
+                    %option{value: "6"} おもちゃ・ホビー・グッズ
+                    %option{value: "7"} コスメ・香水・美容
+                    %option{value: "8"} 家電・スマホ・カメラ
+                    %option{value: "9"} スポーツ・レビュー
+                    %option{value: "10"} ハンドメイド
+                    %option{value: "11"} チケット
+                    %option{value: "12"} 自動車・オートバイ
+                    %option{value: "13"} その他
+              .form-group
+                %label.item-detail__state 
+                  商品の状態
+                  %span.form-require 必須
+                .select-wrap
+                  %i.fas.fa-angle-down
+                  %select.select-wrap__input
+                    %option{value: ""} ---
+                    %option{value: "1"} 新品、未使用
+                    %option{value: "2"} 未使用に近い
+                    %option{value: "3"} 目立った傷や汚れなし
+                    %option{value: "4"} やや傷や汚れあり
+                    %option{value: "5"} 傷や汚れあり
+                    %option{value: "6"} 全体的に状態が悪い
+          
+          .container__form__content.delivery-setting.clearfix
+            .delivery-setting__title.form-sub-title 配送について
+            .delivery-setting__rightbox.form-right-box
+              .form-group
+                %label.delivery-setting__burden
+                  配送料の負担
                   %span.form-require 
                     必須
-              .selling-item__price__inner-right
-                ¥
-                .selling-item__price__inner-right--input
-                  %input{placeholder: "例)  300", value: ""}
-            %li.selling-item__fee.clearfix
-              %p 販売手数料(10%)
-              %p -
-            %li.selling-item__profit.clearfix
-              %p.selling-item__profit--title 販売利益
-              %p.selling-item__profit--result -
+                .select-wrap
+                  %i.fas.fa-angle-down
+                  %select.select-wrap__input
+                    %option{value: ""} ---
+                    %option{value: "1"} 送料込み(出品者負担)
+                    %option{value: "2"} 着払い(購入者負担)
+              .form-group
+                %label.delivery-setting__region
+                  発送元の地域
+                  %span.form-require 
+                    必須
+                .select-wrap
+                  %i.fas.fa-angle-down
+                  %select.select-wrap__input
+                    %option{value: ""} ---
+                    - Prefecture.all.each do |ele|
+                      %option{value: ele.name}= ele.name
+
+              .form-group
+                %label.delivery-setting__days
+                  発送までの日数
+                  %span.form-require 
+                    必須
+                .select-wrap
+                  %i.fas.fa-angle-down
+                  %select.select-wrap__input
+                    %option{value: ""} ---
+                    %option{value: "1"} 1~2日で発送
+                    %option{value: "2"} 2~3日で発送
+                    %option{value: "3"} 4~7日で発送
+
+          .container__form__content.selling-item.clearfix
+            .selling-item__title.form-sub-title
+              販売価格(300〜9,999,999)
+            %ul.selling-item__right-box.form-right-box
+              %li.form-group.selling-item__price
+                .selling-item__price__inner-left
+                  %label.selling-item__price--setting
+                    価格
+                    %span.form-require 
+                      必須
+                .selling-item__price__inner-right
+                  ¥
+                  .selling-item__price__inner-right--input
+                    %input{placeholder: "例)  300", value: ""}
+              %li.selling-item__fee.clearfix
+                %p 販売手数料(10%)
+                %p -
+              %li.selling-item__profit.clearfix
+                %p.selling-item__profit--title 販売利益
+                %p.selling-item__profit--result -
         
         .container__form__content.confirmation-box.clearfix
           .confirmation-box__description

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -46,21 +46,7 @@
                   %span.form-require 必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  %select.select-wrap__input
-                    %option{value: ""} ---
-                    %option{value: "1"} レディース
-                    %option{value: "2"} メンズ
-                    %option{value: "3"} ベビー・キッズ
-                    %option{value: "4"} インテリア・住まい・小物
-                    %option{value: "5"} 本・音楽・ゲーム
-                    %option{value: "6"} おもちゃ・ホビー・グッズ
-                    %option{value: "7"} コスメ・香水・美容
-                    %option{value: "8"} 家電・スマホ・カメラ
-                    %option{value: "9"} スポーツ・レビュー
-                    %option{value: "10"} ハンドメイド
-                    %option{value: "11"} チケット
-                    %option{value: "12"} 自動車・オートバイ
-                    %option{value: "13"} その他
+                  = f.collection_select :p_category_id, Category.where("id < ?", 14), :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
               .form-group
                 %label.item-detail__state 
                   商品の状態
@@ -97,7 +83,7 @@
                     必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  = f.collection_select :city, Prefecture.all, :id, :name, {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.collection_select :city, Prefecture.all, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
 
               .form-group
                 %label.delivery-setting__days

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -53,14 +53,7 @@
                   %span.form-require 必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  %select.select-wrap__input
-                    %option{value: ""} ---
-                    %option{value: "1"} 新品、未使用
-                    %option{value: "2"} 未使用に近い
-                    %option{value: "3"} 目立った傷や汚れなし
-                    %option{value: "4"} やや傷や汚れあり
-                    %option{value: "5"} 傷や汚れあり
-                    %option{value: "6"} 全体的に状態が悪い
+                  = f.select :state, [["新品、未使用", 1], ["未使用に近い", 2], ["目立った傷や汚れなし", 3], ["やや傷や汚れあり", 4], ["傷や汚れあり", 5], ["全体的に状態が悪い", 6]], {prompt: "---"}, {class: "select-wrap__input"}
           
           .container__form__content.delivery-setting.clearfix
             .delivery-setting__title.form-sub-title 配送について

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -98,7 +98,7 @@
                 .selling-item__price__inner-right
                   ¥
                   .selling-item__price__inner-right--input
-                    %input{placeholder: "例)  300", value: ""}
+                    = f.text_field :price, placeholder: "例)  300"
               %li.selling-item__fee.clearfix
                 %p 販売手数料(10%)
                 %p -

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -83,11 +83,7 @@
                     必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  %select.select-wrap__input
-                    %option{value: ""} ---
-                    %option{value: "1"} 1~2日で発送
-                    %option{value: "2"} 2~3日で発送
-                    %option{value: "3"} 4~7日で発送
+                  = f.select :delivery_days, [["1~2日で発送", 1], ["2~3日で発送", 2], ["4~7日で発送", 3]], {prompt: "---"}, {class: "select-wrap__input"}
 
           .container__form__content.selling-item.clearfix
             .selling-item__title.form-sub-title

--- a/app/views/shared/_sell-button.html.haml
+++ b/app/views/shared/_sell-button.html.haml
@@ -1,4 +1,5 @@
-.icon-sell-btn
-  .icon-sell-btn__text
-    出品
-  %i.fa.fa-camera
+= link_to new_item_path do
+  %span.icon-sell-btn
+    .icon-sell-btn__text
+      出品
+    %i.fa.fa-camera

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,5 @@ Rails.application.routes.draw do
   get "users/addCard" => "users#addCard"
   resources :users, only: [:show]
   get 'items/detail' => 'items#detail'
-  resources :items, only: [:new]
+  resources :items, only: [:new, :create]
 end


### PR DESCRIPTION
# What
商品出品機能を作成しました。
（最低限の出品機能のみです。バリデーションやテスト、動的なフォームの変更、画像の複数枚保存等、未着手の機能は別で実装します。）

# Why
サービスに必須の機能であるため。

# 備考
- [このプルリクエストに対応するTrelloのカード](https://trello.com/c/NYD3xaWC/15-%E3%80%90%E3%82%B5%E3%83%BC%E3%83%90%E3%82%B5%E3%82%A4%E3%83%89%E3%80%91%E5%95%86%E5%93%81%E5%87%BA%E5%93%81)
- 本来、はじめは隠れているべきフォームも含め、現状は全ての入力フォームを表示しています。
- category_idカラムには、孫カテゴリ（三段目）の値が保存されるようにしています。
- 商品を出品する際は、本来current_user.idが必要になります（ログインしているユーザーのIDを、`saler_id` カラムに保存し、商品出品者を明確にするため）。
現状は、ユーザー登録機能が未実装のため、saler_idカラムには "1" を保存するようにしています。**出品機能を使う際は、コンソールやSequel Pro等でUsersテーブルに"ID: 1"のレコードを作成の上、ご使用ください。**

## 参考にした情報など
- 外部キーのnil許可設定について
itemsテーブルには、「buyer_id」カラム（商品購入者のid）を保存するよう設定していますが、
商品出品時点では購入者はいないので、値はnilになります。
しかし、**belongs_toによって外部キーを使用している場合は、デフォルトでは値が必須となるようです**。（＝nilの場合は、データを保存できない。）
- 対応として、オプションに `optional: true` をつけることによって、nilでも保存できるようになるようです。
もし他の部分の実装でも同様のケースがあれば、以下を参考にしてみてください。
- [Rails5からbelongs_to関連はデフォルトでrequired: trueになる](https://qiita.com/iguchi1124/items/218e35a145f372062ea4)
