### PR TITLE
マイグレーションファイルの復活

### DIFF
--- a/db/migrate/20190813140306_create_images.rb
+++ b/db/migrate/20190813140306_create_images.rb
@@ -1,0 +1,9 @@
+class CreateImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :images do |t|
+      t.text        :image
+      t.references  :item,  null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end


### PR DESCRIPTION
# What
過去に削除してしまったマイグレーションファイルを取得し、復活させました。

# Why
過去にrails g migrationコマンドを実行し、マイグレーションファイルを削除してしまったことにより、エラーが発生しているため。


[※マイグレーションファイルを削除したコミット](https://github.com/seimangorira/freemarket_sample_50a/pull/44/commits/0527dcf54e710cd69e0f49f03e6bd92ee1f4b6f2)