### PR TITLE
「delivery_days」カラム（itemsテーブル）の型修正

### DIFF
--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -115,7 +115,7 @@
                 .select-wrap
                   %i.fas.fa-angle-down
                   -# 現状、カラムの型が「date」になっているため、修正の必要あり。出品機能の実装のため、仮でDate.todayと設定。
-                  = f.select :delivery_days, [["1~2日で発送", Date.today], ["2~3日で発送", Date.today], ["4~7日で発送", Date.today]], {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.select :delivery_days, [["1~2日で発送", 1], ["2~3日で発送", 2], ["4~7日で発送", 3]], {prompt: "---"}, {class: "select-wrap__input"}
 
           .container__form__content.selling-item.clearfix
             .selling-item__title.form-sub-title

--- a/db/migrate/20190821121932_change_datatype_delivery_days_of_items.rb
+++ b/db/migrate/20190821121932_change_datatype_delivery_days_of_items.rb
@@ -1,0 +1,5 @@
+class ChangeDatatypeDeliveryDaysOfItems < ActiveRecord::Migration[5.2]
+  def change
+    change_column :items, :delivery_days, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_18_081524) do
+ActiveRecord::Schema.define(version: 2019_08_21_121932) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -66,7 +66,7 @@ ActiveRecord::Schema.define(version: 2019_08_18_081524) do
     t.integer "delivery_fee", null: false
     t.integer "delivery_method", null: false
     t.string "city", null: false
-    t.date "delivery_days", null: false
+    t.integer "delivery_days", null: false
     t.bigint "category_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# What
itemsテーブルの「delivery_days」のカラムの型について、dateからintegerに修正しました。

# Why
適切な型設定ではなかったため。
（「1〜2日で発送」、「2~3日で発送」、「4〜7日で発送」の選択肢から選ぶため、日付を保存するカラムではなかった。）
