### PR TITLE
商品出品機能のバリデーション追加、及びenumの導入

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,6 @@
 class ItemsController < ApplicationController
+  # ユーザー登録機能作成後に、コメントアウトを外す
+  # before_action :authenticate_user! except: [:index, :detail]
 
   def index
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,4 +24,10 @@ class Item < ApplicationRecord
 
   # ActiveStorageのバリデーションは未実装
   
+  # 選択肢のenum化
+  enum size: {under_XXS: 1, XS: 2, S: 3, M: 4, L: 5, XL: 6, double_XL: 7, triple_XL: 8, over_4XL: 9, FREESIZE: 10}
+  enum state: {unused: 1, near_unused: 2, no_dirts: 3, some_dirts: 4, have_dirts: 5, bad_condition: 6}
+  enum delivery_fee: {postage_included: 1, cash_on_delivery: 2}
+  enum delivery_method: {undecided: 1, mercari: 2, post_office_mail: 3, letter_pack: 4, regular_mail: 5, yamato: 6, post_office_pack: 7, click_post: 8, post_office_packet: 9}
+  enum delivery_day: { early: 0, middle: 1, late: 2}
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,4 +7,21 @@ class Item < ApplicationRecord
 
   belongs_to :saler, class_name: "User"
   belongs_to :buyer, class_name: "User", optional: true
+
+  # 商品出品時、編集時のバリデーション
+  validates :name, presence: true, length: { maximum: 40 }
+  validates :price, numericality: { only_integer: true, greater_than_or_equal: 300, less_than_or_equal_to: 9999999 }
+  validates :introduction, presence: true, length: { maximum: 1000 }
+
+  with_options presence: true do
+    validates :state
+    validates :delivery_fee
+    validates :delivery_method
+    validates :city
+    validates :delivery_days
+    validates :category_id
+  end
+
+  # ActiveStorageのバリデーションは未実装
+  
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -60,7 +60,7 @@
                     %span.form-require 必須
                   .select-wrap
                     %i.fas.fa-angle-down
-                    = f.select :size, [["XXS以下", 0], ["XS(SS)", 1],["S",2],["M",3],["L", 4],["XL(LL)",5],["2XL(3L)", 6],["3XL(4L)", 7],["4XL(5L以上)", 8],["FREE SIZE", 9]], {prompt: "---"} , class:"select-wrap__input"
+                    = f.select :size, Item.sizes_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
 
                 .form-group
                   %label.item-detail__category 
@@ -75,7 +75,7 @@
                   %span.form-require 必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  = f.select :state, [["新品、未使用", 1], ["未使用に近い", 2], ["目立った傷や汚れなし", 3], ["やや傷や汚れあり", 4], ["傷や汚れあり", 5], ["全体的に状態が悪い", 6]], {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.select :state, Item.states_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
           
           .container__form__content.delivery-setting.clearfix
             .delivery-setting__title.form-sub-title 配送について
@@ -87,7 +87,7 @@
                     必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  = f.select :delivery_fee, [["送料込み(出品者負担)", 1], ["着払い(購入者負担)", 2]], {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.select :delivery_fee, Item.delivery_fees_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
               
               .form-group
                 %label.delivery-setting__burden
@@ -96,7 +96,7 @@
                     必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  = f.select :delivery_method, [["未定", 1], ["らくらくメルカリ便", 2], ["ゆうメール", 3], ["レターパック", 4], ["普通郵便(定形、定形外)", 5], ["クロネコヤマト", 6], ["ゆうパック", 7], ["クリックポスト", 8], ["ゆうパケット", 9]], {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.select :delivery_method, Item.delivery_methods_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
 
               .form-group
                 %label.delivery-setting__region
@@ -114,9 +114,8 @@
                     必須
                 .select-wrap
                   %i.fas.fa-angle-down
-                  -# 現状、カラムの型が「date」になっているため、修正の必要あり。出品機能の実装のため、仮でDate.todayと設定。
-                  = f.select :delivery_days, [["1~2日で発送", 1], ["2~3日で発送", 2], ["4~7日で発送", 3]], {prompt: "---"}, {class: "select-wrap__input"}
-
+                  = f.select :delivery_days, Item.delivery_days_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
+                  
           .container__form__content.selling-item.clearfix
             .selling-item__title.form-sub-title
               販売価格(300〜9,999,999)

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,8 @@ module FreemarketSample50a
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.i18n.default_locale = :ja
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,41 @@
+ja:
+  activerecord:
+    models:
+      item: 商品
+  enums:
+    item:
+      size:
+        under_XXS: "XXS以下"
+        XS: "XS(SS)"
+        S: "S"
+        M: "M"
+        L: "L"
+        XL: "XL(LL)"
+        double_XL: "2XL(3L)"
+        triple_XL: "3XL(4L)"
+        over_4XL: "4XL(5L以上)"
+        FREESIZE: "FREE SIZE"
+      state:
+        unused: "新品、未使用"
+        near_unused: "未使用に近い"
+        no_dirts: "目立った傷や汚れなし"
+        some_dirts: "やや傷や汚れあり"
+        have_dirts: "傷や汚れあり"
+        bad_condition: "全体的に状態が悪い"
+      delivery_fee:
+        postage_included: "送料込み(出品者負担)"
+        cash_on_delivery: "着払い(購入者負担)"
+      delivery_method:
+        undecided: "未定"
+        mercari: "らくらくメルカリ便"
+        post_office_mail: "ゆうメール"
+        letter_pack: "レターパック"
+        regular_mail: "普通郵便(定形、定形外)"
+        yamato: "クロネコヤマト"
+        post_office_pack: "ゆうパック"
+        click_post: "クリックポスト"
+        post_office_packet: "ゆうパケット"
+      delivery_day:
+        early: "1~2日で発送"
+        middle: "2~3日で発送"
+        late: "4~7日で発送"


### PR DESCRIPTION
# What
- 商品出品時のバリデーションを追加しました（商品画像除く）。
- itemsテーブルの各カラムについて、enumに対応しました。

# Why
商品出品時に入力状況を適切に制限できるようにするため。
商品詳細画面等で、データベースの値（integer型）から文字列を取得できるようにするため。

# 備考
- [このプルリクエストに対応するTrelloのカード](https://trello.com/c/NYD3xaWC/15-%E3%80%90%E3%82%B5%E3%83%BC%E3%83%90%E3%82%B5%E3%82%A4%E3%83%89%E3%80%91%E5%95%86%E5%93%81%E5%87%BA%E5%93%81)
- 実装途中で、以下のTODOが残っていますが、商品詳細画面の実装に必要となるため一度マージしたいと思います。
- enumについては、カリキュラム「[モデルの便利な機能を利用しよう](https://master.tech-camp.in/curriculums/2936)」をご参照ください。いろんなやり方があるということで、こちらも試しに使ってみています。

### 今後のTODO
- 商品画像のバリデーション追加
- カテゴリー、サイズ等のフォームを動的に表示
- 価格入力フォームの動的な表示
- 商品画像選択フォームを動的に変更
- 出品中、交渉中、出品停止の状態設定