### PR TITLE
商品出品フォームの項目を動的に変更

### DIFF
--- a/app/assets/javascripts/calculation.js
+++ b/app/assets/javascripts/calculation.js
@@ -3,8 +3,8 @@ $(document).on("turbolinks:load", function(){
     var saleFee = Math.floor(inputPrice * 0.1); //Math.floorで小数点以下を切り捨て
     var saleProfit = inputPrice - saleFee;
 
-    $('.sale-fee').text(`¥${saleFee}`);
-    $('.selling-item__profit--result').text(`¥${saleProfit}`)
+    $('.sale-fee').text(`¥${saleFee.toLocaleString()}`); //.toLocaleString()で、価格をコンマ区切りで表示
+    $('.selling-item__profit--result').text(`¥${saleProfit.toLocaleString()}`)
   }
 
   $('#selling-item-price').on('keyup', function() {

--- a/app/assets/javascripts/calculation.js
+++ b/app/assets/javascripts/calculation.js
@@ -1,0 +1,19 @@
+$(document).on("turbolinks:load", function(){
+  function feeCalculation(inputPrice){
+    var saleFee = inputPrice * 0.1;
+    var saleProfit = inputPrice - saleFee;
+
+    $('.sale-fee').text(`¥${saleFee}`);
+    $('.selling-item__profit--result').text(`¥${saleProfit}`)
+  }
+
+  $('#selling-item-price').on('keyup', function() {
+    var inputPrice = $('#selling-item-price').val();
+    if ( 300 <= inputPrice && inputPrice <= 9999999) {  //価格が¥300〜¥9,999,999のときにtextを書き換え
+      feeCalculation(inputPrice) 
+    } else { //それ以外のときは、textを'-'に書き換え
+      $('.sale-fee').text('-');
+      $('.selling-item__profit--result').text('-');
+    }
+  });
+});

--- a/app/assets/javascripts/calculation.js
+++ b/app/assets/javascripts/calculation.js
@@ -1,6 +1,6 @@
 $(document).on("turbolinks:load", function(){
   function feeCalculation(inputPrice){
-    var saleFee = inputPrice * 0.1;
+    var saleFee = Math.floor(inputPrice * 0.1); //Math.floorで小数点以下を切り捨て
     var saleProfit = inputPrice - saleFee;
 
     $('.sale-fee').text(`¥${saleFee}`);

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -42,8 +42,8 @@ $(document).on("turbolinks:load", function(){
       .done(function(children){
         $('#children_wrapper').remove(); //親が変更された時、子以下を削除する
         $('#grandchildren_wrapper').remove();
-        $('#size_wrapper').remove();
-        $('#brand_wrapper').remove();
+        $('.select-item-sizes').css('display', 'none');
+        $('.input-item-brands').css('display', 'none');
         var insertHTML = '';
         children.forEach(function(child){
           insertHTML += appendOption(child);
@@ -56,8 +56,8 @@ $(document).on("turbolinks:load", function(){
     } else{
       $('#children_wrapper').remove(); //親カテゴリが初期値になった時、子以下を削除する
       $('#grandchildren_wrapper').remove();
-      $('#size_wrapper').remove();
-      $('#brand_wrapper').remove();
+      $('.select-item-sizes').css('display', 'none');
+      $('.input-item-brands').css('display', 'none');
     }
   });
 
@@ -73,8 +73,8 @@ $(document).on("turbolinks:load", function(){
       })
       .done(function(grandchildren){
         $('#grandchildren_wrapper').remove();  //子が変更された時、孫以下を削除する
-        $('#size_wrapper').remove();
-        $('#brand_wrapper').remove();
+        $('.select-item-sizes').css('display', 'none');
+        $('.input-item-brands').css('display', 'none');
         var insertHTML = '';
         grandchildren.forEach(function(grandchild){
           insertHTML += appendOption(grandchild);
@@ -86,8 +86,14 @@ $(document).on("turbolinks:load", function(){
       })
     } else{
       $('#grandchildren_wrapper').remove();  //子カテゴリが初期値になった時、孫以下を削除する
-      $('#size_wrapper').remove();
-      $('#brand_wrapper').remove();
+      $('.select-item-sizes').css('display', 'none');
+      $('.input-item-brands').css('display', 'none');
     }
+  });
+
+  // 孫カテゴリ選択後にサイズ・ブランドを表示
+  $(document).on('change', '#grandchild_category', function(){
+    $('.select-item-sizes').css('display', 'block');
+    $('.input-item-brands').css('display', 'block');
   });
 });

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -1,0 +1,93 @@
+$(document).on("turbolinks:load", function(){
+  // カテゴリセレクトボックスのオプションを作成
+  function appendOption(category){
+    var option = `<option value="${category.id}" data-category="${category.id}">${category.name}</option>`;
+    return option;
+  }
+  
+  // 子カテゴリの表示作成
+  function appendChidrenBox(insertHTML){
+    var childSelectBox = `<div class="select-wrap" id="children_wrapper">
+                                <i class="fas fa-angle-down"></i>
+                                <select class="select-wrap__input" id="child_category" name="">
+                                  <option value="" data-category="---">---</option>
+                                  ${insertHTML}
+                                </select>
+                             </div>`;
+    $('.select-categories-wrapper').append(childSelectBox);
+  }
+
+  // 孫カテゴリの作成
+  function appendGrandChidrenBox(insertHTML){
+    var grandChildSelectBox = `<div class="select-wrap" id="grandchildren_wrapper">
+                                <i class="fas fa-angle-down"></i>
+                                <select class="select-wrap__input" id="grandchild_category" name="item[category_id">
+                                  <option value="---" data-category="---">---</option>
+                                  ${insertHTML}
+                                </select>
+                             </div>`;
+    $('.select-categories-wrapper').append(grandChildSelectBox);
+  }
+
+  // 親カテゴリ選択後のイベント
+  $('#parent_category').on('change', function(){
+    var parentCategory = $('#parent_category').val(); //選択された親カテゴリのidを取得
+    if (parentCategory != ""){ //親カテゴリが初期値（null）でないことを確認
+      $.ajax({
+        url: '/items/get_children_categories',
+        type: 'GET',
+        data: { parent_id: parentCategory },
+        dataType: 'json'
+      })
+      .done(function(children){
+        $('#children_wrapper').remove(); //親が変更された時、子以下を削除する
+        $('#grandchildren_wrapper').remove();
+        $('#size_wrapper').remove();
+        $('#brand_wrapper').remove();
+        var insertHTML = '';
+        children.forEach(function(child){
+          insertHTML += appendOption(child);
+        });
+        appendChidrenBox(insertHTML);
+      })
+      .fail(function(){
+        alert('カテゴリ取得に失敗しました');
+      })
+    } else{
+      $('#children_wrapper').remove(); //親カテゴリが初期値になった時、子以下を削除する
+      $('#grandchildren_wrapper').remove();
+      $('#size_wrapper').remove();
+      $('#brand_wrapper').remove();
+    }
+  });
+
+  // 小カテゴリ選択後のイベント
+  $(document).on('change', '#child_category', function(){
+    var childCategory = $('#child_category').val(); //選択された子カテゴリのidを取得
+    if (childCategory != ""){ //子カテゴリが初期値（null）でないことを確認
+      $.ajax({
+        url: '/items/get_grandchildren_categories',
+        type: 'GET',
+        data: { child_id: childCategory },
+        dataType: 'json'
+      })
+      .done(function(grandchildren){
+        $('#grandchildren_wrapper').remove();  //子が変更された時、孫以下を削除する
+        $('#size_wrapper').remove();
+        $('#brand_wrapper').remove();
+        var insertHTML = '';
+        grandchildren.forEach(function(grandchild){
+          insertHTML += appendOption(grandchild);
+        });
+        appendGrandChidrenBox(insertHTML);
+      })
+      .fail(function(){
+        alert('カテゴリ取得に失敗しました');
+      })
+    } else{
+      $('#grandchildren_wrapper').remove();  //子カテゴリが初期値になった時、孫以下を削除する
+      $('#size_wrapper').remove();
+      $('#brand_wrapper').remove();
+    }
+  });
+});

--- a/app/assets/javascripts/delivery.js
+++ b/app/assets/javascripts/delivery.js
@@ -1,5 +1,5 @@
 $(document).on("turbolinks:load", function(){
-  // 購入者が負担時の「配送の方法」フォームを作成
+  // 「着払い」時に利用する「配送の方法」フォームを作成
   function appendDeliveryMethodBuyer(){
      var deliveryMethod = ` <div id="add-delivery-method">
                               <label class="delivery-setting__burden">配送の方法
@@ -20,15 +20,15 @@ $(document).on("turbolinks:load", function(){
 
   // 「配送料の負担」選択後のイベント
   $('#delivery-fee').on('change', function(){
-    var deliveryBurden = $('#delivery-fee').val(); //選択された「配送の負担」のidのvalを取得
-    if (deliveryBurden == "postage_included") { //出品者負担が選択された場合の処理を記述
+    var deliveryBurden = $('#delivery-fee').val(); //「送料込み」、「着払い」のいずれであるかを取得
+    if (deliveryBurden == "postage_included") { //「送料込み」が選択された場合の処理を記述
       $('#add-delivery-method').remove();
-      $(".default-delivery-setting").css('display', 'block');
-    } else if (deliveryBurden == "cash_on_delivery") { //購入者負担が選択された場合の処理を記述
-      $(".default-delivery-setting").css('display', 'none');
+      $(".default-delivery-method").css('display', 'block');
+    } else if (deliveryBurden == "cash_on_delivery") { //「着払い」が選択された場合の処理を記述
+      $(".default-delivery-method").css('display', 'none');
       appendDeliveryMethodBuyer();
     } else { //「配送料の負担」が初期値になった時、「配送の方法」フォームを削除する
-      $(".default-delivery-setting").css('display', 'none');
+      $(".default-delivery-method").css('display', 'none');
       $('#add-delivery-method').remove(); 
     }
   });

--- a/app/assets/javascripts/delivery.js
+++ b/app/assets/javascripts/delivery.js
@@ -1,0 +1,35 @@
+$(document).on("turbolinks:load", function(){
+  // 購入者が負担時の「配送の方法」フォームを作成
+  function appendDeliveryMethodBuyer(){
+     var deliveryMethod = ` <div id="add-delivery-method">
+                              <label class="delivery-setting__burden">配送の方法
+                                <span class="form-require">必須</span>
+                              </label>
+                              <div class="select-wrap">
+                                <i class="fas fa-angle-down"></i>
+                                <select class="select-wrap__input" name="item[delivery_method]" id="item_delivery_method"><option value="">---</option>
+                                  <option value="undecided">未定</option>
+                                  <option value="yamato">クロネコヤマト</option>
+                                  <option value="post_office_pack">ゆうパック</option>
+                                  <option value="post_office_mail">ゆうメール</option>
+                                </select>
+                              </div>
+                            </div>`
+    $('.select_delivery_wrapper').append(deliveryMethod);
+  }
+
+  // 「配送料の負担」選択後のイベント
+  $('#delivery-fee').on('change', function(){
+    var deliveryBurden = $('#delivery-fee').val(); //選択された「配送の負担」のidのvalを取得
+    if (deliveryBurden == "postage_included") { //出品者負担が選択された場合の処理を記述
+      $('#add-delivery-method').remove();
+      $(".default-delivery-setting").css('display', 'block');
+    } else if (deliveryBurden == "cash_on_delivery") { //購入者負担が選択された場合の処理を記述
+      $(".default-delivery-setting").css('display', 'none');
+      appendDeliveryMethodBuyer();
+    } else { //「配送料の負担」が初期値になった時、「配送の方法」フォームを削除する
+      $(".default-delivery-setting").css('display', 'none');
+      $('#add-delivery-method').remove(); 
+    }
+  });
+});

--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -1,18 +1,18 @@
 $(document).on("turbolinks:load", function(){
   // アップロードされた画像のプレビューを作成
   function appendItemList(num){
-    // 画像のsrcは現在仮置き。非同期処理で受け取る？
+    // TODO: 画像のsrcは現在仮置き。非同期処理で受け取る？
     var itemList= ` <li class="image-lists__list">
                       <div class="item-image-wrapper__figure">
                         <img alt="イメージ1" src="/assets/mercari_icon-a5e045c514dd34e9171bdac1f50da42d19c64cba883501f8e3521a5e51b0c57b.png">
                       </div>
                       <div class="item-image-wrapper__button">
                         <a href="#">編集</a>
-                        <a href="#">削除</a>
+                        <a href="#" class="delete-uploaded-image" data-image-id="${num}">削除</a>
                       </div>
                     </li>`
-    // 画像が5枚以下のときは上部のリストに、5枚以上のときは下部のリストに追加
-    if (num < 5 ) {
+    // 画像が5枚以下のときは上部のリストに、6枚以上のときは下部のリストに追加
+    if (num < 6 ) {
       $('.first-image-lists').append(itemList);
     } else {
       $('.second-image-lists').append(itemList);
@@ -22,15 +22,15 @@ $(document).on("turbolinks:load", function(){
   // アップロードされた画像の枚数に応じて、ファイルフィールドの大きさを変更
   function changeDropBoxSizes(num) {
     // 計算用の数値を定義。
-    num < 5 ? calNum = num + 1 : calNum = num - 4;
+    num < 6 ? calNum = num : calNum = num - 5;
     
     var inputWrapper = $('.upload-images__container--now-upload')
-    if (num == 4 ) {
-      // 既に4枚存在するときは、inputWrapperのサイズをデフォルトのサイズに戻し、プレビューの下部に表示する
+    if (num == 0 || num == 5 ) {
+      // 5枚になるときは、inputWrapperのサイズをデフォルトのサイズに戻し、プレビューの下部に表示する
       inputWrapper.width(620);
       inputWrapper.css('margin-left', '0');
-    } else if (num == 9) {
-      // 既に9枚存在するときは、追加でアップロードができないよう、ファイルフィールドを隠す
+    } else if (num == 10) {
+      // 10枚になるときは、追加でアップロードができないよう、ファイルフィールドを隠す
       inputWrapper.css('display', 'none');
     } else {
       // プレビューされる画像の枚数に応じて、ファイルフィールドのサイズを変更
@@ -38,16 +38,33 @@ $(document).on("turbolinks:load", function(){
       inputWrapper.width(newWidth);
       inputWrapper.css('margin-left', '2%');
     }
-
-    // カスタムデータ属性の'data-total-items'を更新(1増加させる)
-    var newNumId = num + 1
-    $('.now-upload-wrapper--input')[0].dataset.totalItems = newNumId
   }
 
   // ファイルがアップロードされたときの処理
   $('.now-upload-wrapper--input').on('change', function(){
     var uploadedNum = Number($(this).attr('data-total-items')); // 現在アップロードされている画像の枚数を取得し、整数に変換
-    appendItemList(uploadedNum);  // 画像のプレビューを作成
-    changeDropBoxSizes(uploadedNum) // ファイルボックスの大きさを変更
+    var afterUploadNum = uploadedNum + 1  
+
+    appendItemList(afterUploadNum);  // 画像のプレビューを作成
+    changeDropBoxSizes(afterUploadNum); // ファイルボックスの大きさを変更
+
+    $(this)[0].dataset.totalItems = afterUploadNum // カスタムデータ属性の'data-total-items'を更新(1増加させる)
   });
+
+  // ファイルが削除されたときの処理
+  // TODO: 実際にform_withで選択されたファイルを削除する処理も追記する必要あり
+  $(document).on('click', '.delete-uploaded-image', function() {
+    event.preventDefault(); // aタグクリックによる画面遷移を防ぐ
+    $(this).parents("li").remove(); // 親要素のliを取得して削除
+
+    var uploadedNum = Number($('.now-upload-wrapper--input').attr('data-total-items'));
+    var afterDeleteNum = uploadedNum - 1
+    changeDropBoxSizes(afterDeleteNum);
+
+    // 選択されている画像が9枚になったときは、再度ファイルフィールドを表示
+    if (afterDeleteNum == 9 ) {
+      $('.upload-images__container--now-upload').css('display', 'inline-block');
+    }
+    $('.now-upload-wrapper--input')[0].dataset.totalItems -= 1; // カスタムデータ属性の'data-total-items'を更新(1減少させる) 
+  })
 });

--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -1,0 +1,53 @@
+$(document).on("turbolinks:load", function(){
+  // アップロードされた画像のプレビューを作成
+  function appendItemList(num){
+    // 画像のsrcは現在仮置き。非同期処理で受け取る？
+    var itemList= ` <li class="image-lists__list">
+                      <div class="item-image-wrapper__figure">
+                        <img alt="イメージ1" src="/assets/mercari_icon-a5e045c514dd34e9171bdac1f50da42d19c64cba883501f8e3521a5e51b0c57b.png">
+                      </div>
+                      <div class="item-image-wrapper__button">
+                        <a href="#">編集</a>
+                        <a href="#">削除</a>
+                      </div>
+                    </li>`
+    // 画像が5枚以下のときは上部のリストに、5枚以上のときは下部のリストに追加
+    if (num < 5 ) {
+      $('.first-image-lists').append(itemList);
+    } else {
+      $('.second-image-lists').append(itemList);
+    }
+  }
+
+  // アップロードされた画像の枚数に応じて、ファイルフィールドの大きさを変更
+  function changeDropBoxSizes(num) {
+    // 計算用の数値を定義。
+    num < 5 ? calNum = num + 1 : calNum = num - 4;
+    
+    var inputWrapper = $('.upload-images__container--now-upload')
+    if (num == 4 ) {
+      // 既に4枚存在するときは、inputWrapperのサイズをデフォルトのサイズに戻し、プレビューの下部に表示する
+      inputWrapper.width(620);
+      inputWrapper.css('margin-left', '0');
+    } else if (num == 9) {
+      // 既に9枚存在するときは、追加でアップロードができないよう、ファイルフィールドを隠す
+      inputWrapper.css('display', 'none');
+    } else {
+      // プレビューされる画像の枚数に応じて、ファイルフィールドのサイズを変更
+      var newWidth = 620 - (calNum * 129);
+      inputWrapper.width(newWidth);
+      inputWrapper.css('margin-left', '2%');
+    }
+
+    // カスタムデータ属性の'data-total-items'を更新(1増加させる)
+    var newNumId = num + 1
+    $('.now-upload-wrapper--input')[0].dataset.totalItems = newNumId
+  }
+
+  // ファイルがアップロードされたときの処理
+  $('.now-upload-wrapper--input').on('change', function(){
+    var uploadedNum = Number($(this).attr('data-total-items')); // 現在アップロードされている画像の枚数を取得し、整数に変換
+    appendItemList(uploadedNum);  // 画像のプレビューを作成
+    changeDropBoxSizes(uploadedNum) // ファイルボックスの大きさを変更
+  });
+});

--- a/app/assets/stylesheets/items/_new_item.scss
+++ b/app/assets/stylesheets/items/_new_item.scss
@@ -84,7 +84,10 @@
                 width: 100%;
                 li:first-child {
                   margin-left: 0;
-                  }
+                }
+                li:nth-child(6) {
+                  margin-left: 0;
+                }
                 li {
                   border: 1px solid #eee;
                   display: inline-block;

--- a/app/assets/stylesheets/items/_new_item.scss
+++ b/app/assets/stylesheets/items/_new_item.scss
@@ -60,7 +60,6 @@
       }
 
       .upload-images {
-        width: 620px;
         padding: 40px;
         @include clearfix;
         &__label {
@@ -74,35 +73,94 @@
         &__container {
           margin: 16px auto 0;
           width: 620px;
-          &__box {
-            background-color: #f5f5f5;
-            border: 1px dashed #ccc;
-            cursor: pointer;
-            float: right;
-            font-size: 0;
-            min-height: 162px;
-            padding: 40px;
-            position: relative;
-            transition: box-shadow ease-out .3s;
-            width: 100%;
-            &--input {
-              touch-action: manipulation;
-              display: none;
-            }
-            pre {
+          &--uploaded {
+            display: inline;
+            .image-lists {
+              float: left;
               display: block;
-              font-family: monospace;
-              position: absolute;
-              top: 50%;
-              left: 16px;
-              right: 16px;
-              text-align: center;
-              font-size: 14px;
-              line-height: 1.5;
-              transform: translate(0, -50%);
-              pointer-events: none;
-              white-space: pre-wrap;
-              word-wrap: break-word;
+              padding: 0;
+              ul {
+                display: block;
+                width: 100%;
+                li:first-child {
+                  margin-left: 0;
+                  }
+                li {
+                  border: 1px solid #eee;
+                  display: inline-block;
+                  margin: 0 0 10px 6px;
+                  position: relative;
+                  vertical-align: top;
+                  width: 116px;
+                  .item-image-wrapper {
+                    &__figure {
+                      height: 116px;
+                      max-width: 100%;
+                      padding: 0;
+                      position: relative;
+                      overflow: hidden;
+                      background: #f5f5f5;
+                      img {
+                        height: 114px;
+                        width: 114px;
+                        cursor: default;
+                        vertical-align: middle;
+                      }
+                    }
+                    &__button {
+                      font-size: 14px;
+                      a {
+                        background: #f5f5f5;
+                        display: inline-block;
+                        line-height: 44px;
+                        text-align: center;
+                        width: 50%;
+                        color: #0099e8;
+                        text-decoration: none;
+                      }
+                      a:last-child {
+                        border-left: 1px solid #eee;
+                        float: right;
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+          &--now-upload {
+            width: 100%;
+            margin-left: 0;
+            .now-upload-wrapper {
+              background-color: #f5f5f5;
+              border: 1px dashed #ccc;
+              cursor: pointer;
+              float: right;
+              font-size: 0;
+              min-height: 162px;
+              padding: 40px;
+              position: relative;
+              transition: box-shadow ease-out .3s;
+              width: 100%;
+              &--input {
+                touch-action: manipulation;
+                display: none;
+              }
+              pre {
+                display: block;
+                font-family: monospace;
+                position: absolute;
+                top: 50%;
+                left: 16px;
+                right: 16px;
+                text-align: center;
+                font-size: 14px;
+                line-height: 1.5;
+                transform: translate(0, -50%);
+                pointer-events: none;
+                white-space: pre-wrap;
+                word-wrap: break-word;
+              }
             }
           }
         }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,10 +11,6 @@ class ItemsController < ApplicationController
   def new
     @item = Item.new
     @parent_categories = Category.where(ancestry: nil)
-
-    # 以下は仮実装のため、カテゴリーフォームを動的に作成する際に変更します。
-    @child_categories = Category.where(ancestry: 1)
-    @grandchild_categories = Category.find(14).children
   end
 
   def create
@@ -27,6 +23,14 @@ class ItemsController < ApplicationController
   end
 
   def buy
+  end
+
+  def get_children_categories
+    @children_categories = Category.where(ancestry: params[:parent_id])
+  end
+
+  def get_grandchildren_categories
+    @grandchildren_categories = Category.find(params[:child_id]).children
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   # ユーザー登録機能作成後に、コメントアウトを外す
   # before_action :authenticate_user! except: [:index, :detail]
+  before_action :set_parent_categories, only: [:new, :create, :edit, :update]
 
   def index
   end
@@ -10,7 +11,6 @@ class ItemsController < ApplicationController
   
   def new
     @item = Item.new
-    @parent_categories = Category.where(ancestry: nil)
   end
 
   def create
@@ -39,5 +39,9 @@ class ItemsController < ApplicationController
     params.require(:item).permit(
       :name, :introduction, :category_id, :size, :brand, :state, :delivery_fee, :delivery_method, :city, :delivery_days, :price, images: []
     ).merge(saler_id: User.find(1).id, status: 1)
+  end
+
+  def set_parent_categories
+    @parent_categories = Category.where(ancestry: nil)
   end
 end

--- a/app/views/items/get_children_categories.json.jbuilder
+++ b/app/views/items/get_children_categories.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @children_categories do |child|
+  json.id child.id
+  json.name child.name
+end

--- a/app/views/items/get_grandchildren_categories.json.jbuilder
+++ b/app/views/items/get_grandchildren_categories.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @grandchildren_categories do |grandchild|
+  json.id grandchild.id
+  json.name grandchild.name
+end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -17,15 +17,21 @@
               最大10枚までアップロードできます
             .upload-images__container
               .upload-images__container--uploaded
-                .image-lists{"data-have-item": 0}
-                  %ul
+                .image-lists
+                  %ul.item-image-wrapper.first-image-lists
+                    -# %li.image-lists__list
+                    -#   .item-image-wrapper__figure
+                    -#     = image_tag "mercari_icon.png", alt: "イメージ1"
+                    -#   .item-image-wrapper__button
+                    -#     = link_to "編集", "#"
+                    -#     = link_to "削除", "#"
                 -# 6枚以上選択された際に出現するプレビュー用のラッパー
-                .image-lists.hidden-image-lists{"data-have-item": 0, style: "display: none;"} 
-                  %ul
+                .image-lists
+                  %ul.item-image-wrapper.second-image-lists
               = f.label :images, class: "upload-images__container--now-upload" do
                 -# TODO:jQueryで複数枚アップロード機能実装？(have-itemに変数でNoを設定)
-                .now-upload-wrapper{"data-have-total-item": 0}
-                  = f.file_field :images, multiple: true, class: "now-upload-wrapper--input"
+                .now-upload-wrapper
+                  = f.file_field :images, multiple: true, class: "now-upload-wrapper--input", data: {"total-items": 0}
                   %pre.input.upload-images__container--text
                     ドラッグアンドドロップ
                     またはクリックしてファイルをアップロード

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -125,10 +125,10 @@
                 .selling-item__price__inner-right
                   ¥
                   .selling-item__price__inner-right--input
-                    = f.text_field :price, placeholder: "例)  300"
+                    = f.text_field :price, placeholder: "例)  300", id: "selling-item-price"
               %li.selling-item__fee.clearfix
                 %p 販売手数料(10%)
-                %p -
+                %p.sale-fee -
               %li.selling-item__profit.clearfix
                 %p.selling-item__profit--title 販売利益
                 %p.selling-item__profit--result -

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -41,12 +41,13 @@
             .item-detail__title.form-sub-title 商品の詳細
             .item-detail__right-box.form-right-box
               .form-group
-                %label.item-detail__category 
+                %label.item-detail__category
                   カテゴリー
                   %span.form-require 必須
-                .select-wrap
-                  %i.fas.fa-angle-down
-                  = f.collection_select :category_id, @parent_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
+                .select-categories-wrapper
+                  .select-wrap
+                    %i.fas.fa-angle-down
+                    = f.collection_select :category_id, @parent_categories, :id, :name, {prompt: "---"}, {class: "select-wrap__input", id: "parent_category"}
 
                 .form-group
                   %label.item-detail__category 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -15,13 +15,20 @@
                 必須
             .upload-images__addition
               最大10枚までアップロードできます
-            = f.label :images, class: "upload-images__container" do
-              -# TODO:jQueryで複数枚アップロード機能実装？(have-itemに変数でNoを設定)
-              .upload-images__container__box.have-item
-                = f.file_field :images, multiple: true, class: "upload-images__container__box--input"
-                %pre.input.upload-images__container--text
-                  ドラッグアンドドロップ
-                  またはクリックしてファイルをアップロード
+            .upload-images__container
+              .upload-images__container--uploaded
+                .image-lists{"data-have-item": 0}
+                  %ul
+                -# 6枚以上選択された際に出現するプレビュー用のラッパー
+                .image-lists.hidden-image-lists{"data-have-item": 0, style: "display: none;"} 
+                  %ul
+              = f.label :images, class: "upload-images__container--now-upload" do
+                -# TODO:jQueryで複数枚アップロード機能実装？(have-itemに変数でNoを設定)
+                .now-upload-wrapper{"data-have-total-item": 0}
+                  = f.file_field :images, multiple: true, class: "now-upload-wrapper--input"
+                  %pre.input.upload-images__container--text
+                    ドラッグアンドドロップ
+                    またはクリックしてファイルをアップロード
 
           .container__form__content.item-about.clearfix
             .form-group

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -47,12 +47,6 @@
                 .select-wrap
                   %i.fas.fa-angle-down
                   = f.collection_select :category_id, @parent_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
-                .select-wrap
-                  %i.fas.fa-angle-down
-                  = f.collection_select :category_id, @child_categories, :name, :name, {prompt: "---"}, {class: "select-wrap__input"}
-                .select-wrap
-                  %i.fas.fa-angle-down
-                  = f.collection_select :category_id, @grandchild_categories, :id, :name, {prompt: "---"}, {class: "select-wrap__input"}
 
                 .form-group
                   %label.item-detail__category 

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -90,8 +90,8 @@
                   = f.select :delivery_fee, Item.delivery_fees_i18n.invert, {prompt: "---"}, {class: "select-wrap__input", id: "delivery-fee"}
               
               .select_delivery_wrapper.form-group
-                .default-delivery-setting{style: "display: none;"}
-                  %label.delivery-setting__burden
+                .default-delivery-method{style: "display: none;"}
+                  %label.delivery-method__burden
                     配送の方法
                     %span.form-require 
                       必須

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -19,17 +19,9 @@
               .upload-images__container--uploaded
                 .image-lists
                   %ul.item-image-wrapper.first-image-lists
-                    -# %li.image-lists__list
-                    -#   .item-image-wrapper__figure
-                    -#     = image_tag "mercari_icon.png", alt: "イメージ1"
-                    -#   .item-image-wrapper__button
-                    -#     = link_to "編集", "#"
-                    -#     = link_to "削除", "#"
-                -# 6枚以上選択された際に出現するプレビュー用のラッパー
                 .image-lists
                   %ul.item-image-wrapper.second-image-lists
               = f.label :images, class: "upload-images__container--now-upload" do
-                -# TODO:jQueryで複数枚アップロード機能実装？(have-itemに変数でNoを設定)
                 .now-upload-wrapper
                   = f.file_field :images, multiple: true, class: "now-upload-wrapper--input", data: {"total-items": 0}
                   %pre.input.upload-images__container--text

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -49,7 +49,7 @@
                     %i.fas.fa-angle-down
                     = f.collection_select :category_id, @parent_categories, :id, :name, {prompt: "---"}, {class: "select-wrap__input", id: "parent_category"}
 
-                .form-group
+                .form-group.select-item-sizes{style: "display: none;"}
                   %label.item-detail__category 
                     サイズ
                     %span.form-require 必須
@@ -57,7 +57,7 @@
                     %i.fas.fa-angle-down
                     = f.select :size, Item.sizes_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
 
-                .form-group
+                .form-group.input-item-brands{style: "display: none;"}
                   %label.item-detail__category 
                     ブランド
                     %span.form-arbitrary 任意

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -80,18 +80,19 @@
                   配送料の負担
                   %span.form-require 
                     必須
-                .select-wrap
+                .select-wrap.select-delivery-burden
                   %i.fas.fa-angle-down
-                  = f.select :delivery_fee, Item.delivery_fees_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
+                  = f.select :delivery_fee, Item.delivery_fees_i18n.invert, {prompt: "---"}, {class: "select-wrap__input", id: "delivery-fee"}
               
-              .form-group
-                %label.delivery-setting__burden
-                  配送の方法
-                  %span.form-require 
-                    必須
-                .select-wrap
-                  %i.fas.fa-angle-down
-                  = f.select :delivery_method, Item.delivery_methods_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
+              .select_delivery_wrapper.form-group
+                .default-delivery-setting{style: "display: none;"}
+                  %label.delivery-setting__burden
+                    配送の方法
+                    %span.form-require 
+                      必須
+                  .select-wrap
+                    %i.fas.fa-angle-down
+                    = f.select :delivery_method, Item.delivery_methods_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
 
               .form-group
                 %label.delivery-setting__region

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,5 +18,10 @@ Rails.application.routes.draw do
   get "users/addCard" => "users#addCard"
   resources :users, only: [:show]
   get 'items/detail' => 'items#detail'
-  resources :items, only: [:new, :create]
+  resources :items, only: [:new, :create] do
+    collection do
+      get 'get_children_categories', defaults: { format: 'json' }
+      get 'get_grandchildren_categories', defaults: { format: 'json' }
+    end
+  end
 end


### PR DESCRIPTION
# What
商品出品フォームで、以下の点に対応しました。
1. 「カテゴリー」関連の入力欄をjQuery+非同期通信で動的に変更し、適切な項目を選択できるようにしました。
2. 「配送料の負担」選択後に、「配送の方法」フォームが動的に表示されるようにしました。
3.  価格入力後に、手数料と利益を計算して表示するようにしました。
4.  商品画像を登録後、出品枚数に応じてビューを調整するようにしました。

# Why
- 本家の仕様に合わせ、再現度を高めるため。

# 備考
- [このプルリクエストに対応するTrelloのカード](https://trello.com/c/NYD3xaWC/15-%E3%80%90%E3%82%B5%E3%83%BC%E3%83%90%E3%82%B5%E3%82%A4%E3%83%89%E3%80%91%E5%95%86%E5%93%81%E5%87%BA%E5%93%81)
- 画像アップロードの部分は、現状JS側の処理しか記述していないので、実際は最後に選択した画像しか保存されません。
プレビューされる画像も実際のものではなく、サンプル（メルカリのアイコン）が表示されます。
バリデーション等と併せ、別ブランチで必要な処理を書いて対処する予定です。

# 実装画面・機能のキャプチャ
1. [「カテゴリー」、「サイズ」、「ブランド」フォームの表示 ](https://gyazo.com/57f425c1a2544ce9b33db9151fae6dd9)
2. [「 配送の方法」フォームの表示（GIF）](https://gyazo.com/ccdbddb94d6fc6642ab213dc96a8ac92)
3. [「販売価格」入力後の計算（GIF）](https://gyazo.com/942a98c193d5224dec752188516a335e)
4. 商品画像の選択
![商品出品_画像選択](https://user-images.githubusercontent.com/47180776/63773260-c4841f00-c915-11e9-8047-361ae176a574.gif)
