### PR TITLE
出品商品機能の機能拡充

### DIFF
--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -1,10 +1,9 @@
 $(document).on("turbolinks:load", function(){
   // アップロードされた画像のプレビューを作成
   function appendItemList(num){
-    // TODO: 画像のsrcは現在仮置き。非同期処理で受け取る？
     var itemList= ` <li class="image-lists__list">
                       <div class="item-image-wrapper__figure">
-                        <img alt="イメージ1" src="/assets/mercari_icon-a5e045c514dd34e9171bdac1f50da42d19c64cba883501f8e3521a5e51b0c57b.png">
+                        <img id="preview-${num}" alt="preview-${num}">
                       </div>
                       <div class="item-image-wrapper__button">
                         <a href="#">編集</a>
@@ -41,13 +40,22 @@ $(document).on("turbolinks:load", function(){
   }
 
   // ファイルがアップロードされたときの処理
-  $('.now-upload-wrapper--input').on('change', function(){
+  $('.now-upload-wrapper--input').on('change', function(e){
+    var file = e.target.files[0]  // ファイルオブジェクトを取得する
+    var reader = new FileReader(); //FileReaderオブジェクトの生成
+
     var uploadedNum = Number($(this).attr('data-total-items')); // 現在アップロードされている画像の枚数を取得し、整数に変換
     var afterUploadNum = uploadedNum + 1  
 
-    appendItemList(afterUploadNum);  // 画像のプレビューを作成
-    changeDropBoxSizes(afterUploadNum); // ファイルボックスの大きさを変更
+    appendItemList(afterUploadNum);  // プレビュー用のHTMLを作成
+    reader.onload = (function(file){ // 上記で追加したHTMLに対し画像を設定
+      return function(e){
+        $(`#preview-${afterUploadNum}`).attr("src", e.target.result); //作成した指定のIDのimgタグにsrcを付与
+      };
+    })(file);
+    reader.readAsDataURL(file);
 
+    changeDropBoxSizes(afterUploadNum); // ファイルボックスの大きさを変更
     $(this)[0].dataset.totalItems = afterUploadNum // カスタムデータ属性の'data-total-items'を更新(1増加させる)
   });
 

--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -50,6 +50,12 @@ $(document).on("turbolinks:load", function(){
   $('.now-upload-wrapper--input').on('change', function(e){
     var files = e.target.files;
     var len = files.length;
+
+    if (len > 10) {
+      $('.upload-images__container--error-message').append("アップロードできる画像は10枚までです。");
+      return false;
+    }
+
     var uploadedNum = Number($('.now-upload-wrapper').attr('data-total-items')); // 現在アップロードされている画像の枚数を取得し、整数に変換
 
     for (var i = 0; i < len; i++ ) {

--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -50,8 +50,9 @@ $(document).on("turbolinks:load", function(){
       inputWrapper.css('margin-left', '2%');
     }
   }
-
+  
   // ファイルがアップロードされたときの処理
+  $(document).off('change', '.now-upload-wrapper--input:first');
   $(document).on('change', '.now-upload-wrapper--input:first', function(e){
     var files = e.target.files;
     var len = files.length;

--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -83,11 +83,11 @@ $(document).on("turbolinks:load", function(){
 
   // ファイルが削除されたときの処理
   // TODO: 実際にform_withで選択されたファイルを削除する処理も追記する必要あり
+  $(document).off('click', '.delete-uploaded-image');
   $(document).on('click', '.delete-uploaded-image', function() {
     event.preventDefault(); // aタグクリックによる画面遷移を防ぐ
     $(this).parents("li").remove(); // 親要素のliを取得して削除
 
-    // リストの数値。削除したものより、後のリストの番号も1ずつ減らす
     var uploadedNum = Number($('.now-upload-wrapper').attr('data-total-items'));
     var afterDeleteNum = uploadedNum - 1
     changeDropBoxSizes(afterDeleteNum);

--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -44,6 +44,16 @@ $(document).on("turbolinks:load", function(){
     var file = e.target.files[0]  // ファイルオブジェクトを取得する
     var reader = new FileReader(); //FileReaderオブジェクトの生成
 
+    // アップロードされたファイルが画像でない場合は、エラー文を表示して処理を終了
+    // TODO: 以下のコードでは、GIFなどもアップロード可能なため、今後余裕があれば他のやり方を検討する
+    if (file.type.indexOf("image") < 0) {
+      $('.upload-images__container--error-message').append("ファイル形式はjpeg, またはpngが使用できます");
+      console.log('失敗');
+      return false;
+    } else {
+      $('.upload-images__container--error-message').text(""); // エラーメッセージが既に表示されていた場合は削除
+    }
+
     var uploadedNum = Number($(this).attr('data-total-items')); // 現在アップロードされている画像の枚数を取得し、整数に変換
     var afterUploadNum = uploadedNum + 1  
 

--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -25,6 +25,11 @@ $(document).on("turbolinks:load", function(){
     };
   }
 
+  function createNewForm(num) {
+    var newForm = `<input multiple="multiple" class="now-upload-wrapper--input upload-box-${num}" type="file" name="item[images][]" id="item_images" style="z-index: ${num}"></input>`
+    $('.now-upload-wrapper').prepend(newForm);
+  }
+
   // アップロードされた画像の枚数に応じて、ファイルフィールドの大きさを変更
   function changeDropBoxSizes(num) {
     // 計算用の数値を定義。
@@ -47,7 +52,7 @@ $(document).on("turbolinks:load", function(){
   }
 
   // ファイルがアップロードされたときの処理
-  $('.now-upload-wrapper--input').on('change', function(e){
+  $(document).on('change', '.now-upload-wrapper--input:first', function(e){
     var files = e.target.files;
     var len = files.length;
 
@@ -74,6 +79,7 @@ $(document).on("turbolinks:load", function(){
 
       appendItemList(afterUploadNum);  // プレビュー用のHTMLを作成
       createPreview(reader, afterUploadNum); // appendItemListで作成したHTMLに対し、画像を追加
+      createNewForm(afterUploadNum); // 新規フォームを作成
       reader.readAsDataURL(file);
     }
 
@@ -82,13 +88,13 @@ $(document).on("turbolinks:load", function(){
   });
 
   // ファイルが削除されたときの処理
-  // TODO: 実際にform_withで選択されたファイルを削除する処理も追記する必要あり
   $(document).off('click', '.delete-uploaded-image');
   $(document).on('click', '.delete-uploaded-image', function() {
     event.preventDefault(); // aタグクリックによる画面遷移を防ぐ
     $(this).parents("li").remove(); // 親要素のliを取得して削除
 
     var uploadedNum = Number($('.now-upload-wrapper').attr('data-total-items'));
+    $(`.upload-box-${uploadedNum}`).remove();
     var afterDeleteNum = uploadedNum - 1
     changeDropBoxSizes(afterDeleteNum);
 

--- a/app/assets/javascripts/imageUpload.js
+++ b/app/assets/javascripts/imageUpload.js
@@ -56,13 +56,13 @@ $(document).on("turbolinks:load", function(){
   $(document).on('change', '.now-upload-wrapper--input:first', function(e){
     var files = e.target.files;
     var len = files.length;
+    var uploadedNum = Number($('.now-upload-wrapper').attr('data-total-items')); // 現在アップロードされている画像の枚数を取得し、整数に変換
 
-    if (len > 10) {
-      $('.upload-images__container--error-message').append("アップロードできる画像は10枚までです。");
+    // 合計11枚以上画像をアップロードしようとした際に、処理を中止
+    if ( uploadedNum + len > 10) { 
+      $('.upload-images__container--error-message').append("アップロードできる画像は10枚までです。"); 
       return false;
     }
-
-    var uploadedNum = Number($('.now-upload-wrapper').attr('data-total-items')); // 現在アップロードされている画像の枚数を取得し、整数に変換
 
     for (var i = 0; i < len; i++ ) {
       var reader = new FileReader(); //FileReaderオブジェクトの生成

--- a/app/assets/stylesheets/_mixin.scss
+++ b/app/assets/stylesheets/_mixin.scss
@@ -192,3 +192,10 @@
   height: 2px;
   background: #ccc;
 }
+
+@mixin exhibit-error-message {
+  color: $exhibition-red;
+  line-height: 1.5;
+  font-size: 14px;
+  margin: 8px 0 0;
+}

--- a/app/assets/stylesheets/items/_new_item.scss
+++ b/app/assets/stylesheets/items/_new_item.scss
@@ -166,6 +166,12 @@
               }
             }
           }
+          &--error-message {
+            color: $exhibition-red;
+            line-height: 1.5;
+            font-size: 14px;
+            margin: 8px 0 0;
+          }
         }
       }
 

--- a/app/assets/stylesheets/items/_new_item.scss
+++ b/app/assets/stylesheets/items/_new_item.scss
@@ -38,6 +38,10 @@
       }
       .form-group {
         margin: 40px 0 0;
+        .validate-error-message {
+          @include exhibit-error-message;
+          clear: both;
+        }
       }
       .form-group:first-child {
         margin: 0;
@@ -167,10 +171,7 @@
             }
           }
           &--error-message {
-            color: $exhibition-red;
-            line-height: 1.5;
-            font-size: 14px;
-            margin: 8px 0 0;
+            @include exhibit-error-message;
           }
         }
       }
@@ -211,7 +212,7 @@
       .selling-item {
         @include flexBoxForForm;
         li:first-child {
-          padding: 0 0 24px;
+          padding: 0;
           border: 0;
         }
         li {
@@ -244,6 +245,10 @@
                 width: 160px;
               }
             }
+          }
+          &__error-message {
+            @include exhibit-error-message;
+            padding-bottom: 24px;
           }
         }
         &__profit {

--- a/app/form_builders/custom_form_builder.rb
+++ b/app/form_builders/custom_form_builder.rb
@@ -1,0 +1,33 @@
+class CustomFormBuilder < ActionView::Helpers::FormBuilder
+  def pick_errors(attribute)
+    return nil if @object.nil? || (messages = @object.errors.messages[attribute]).nil?
+    list = messages.collect do |message|
+      %{<div class="validate-error-message">
+          <li>#{message}</li>
+        </div>}
+    end.join
+
+    %{<ul class="errors">#{list}</ul>}.html_safe
+  end
+
+  def text_area(attribute, options={})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def select(attribute, collection, options={}, html_options = {})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def collection_select(attribute, collection, value_method, text_method, options = {}, html_options = {})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+  def file_field(attribute, options={})
+    return super if options[:no_errors]
+    super + pick_errors(attribute)
+  end
+
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -37,14 +37,14 @@ class Item < ApplicationRecord
     if images.attached?
       if images.length > 10 
         errors.add(:images, "画像の枚数は最大10枚までです。")
+      elsif images.length == 0
+        errors.add(:images, "画像が1枚以上必要です。")
       end
       images.each do |image|
-        if !image.content_type.in?(%('image/jpec image/png'))
+        if !image.content_type.in?(%('image/jpeg image/png'))
           errors.add(:images, "ファイル形式はjpeg, またはpngが使用できます")
         end
       end
-    else
-      errors.add(:images, "画像が1枚以上必要です。")
     end
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -10,7 +10,7 @@ class Item < ApplicationRecord
 
   # 商品出品時、編集時のバリデーション
   validates :name, presence: true, length: { maximum: 40 }
-  validates :price, numericality: { only_integer: true, greater_than_or_equal: 300, less_than_or_equal_to: 9999999 }
+  validates :price, numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999 }
   validates :introduction, presence: true, length: { maximum: 1000 }
 
   with_options presence: true do

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -20,9 +20,10 @@ class Item < ApplicationRecord
     validates :city
     validates :delivery_days
     validates :category_id
+    validates :images
   end
 
-  # ActiveStorageのバリデーションは未実装
+  validate :image_validates
   
   # 選択肢のenum化
   enum size: {under_XXS: 1, XS: 2, S: 3, M: 4, L: 5, XL: 6, double_XL: 7, triple_XL: 8, over_4XL: 9, FREESIZE: 10}
@@ -30,4 +31,20 @@ class Item < ApplicationRecord
   enum delivery_fee: {postage_included: 1, cash_on_delivery: 2}
   enum delivery_method: {undecided: 1, mercari: 2, post_office_mail: 3, letter_pack: 4, regular_mail: 5, yamato: 6, post_office_pack: 7, click_post: 8, post_office_packet: 9}
   enum delivery_day: { early: 0, middle: 1, late: 2}
+
+  private
+  def image_validates
+    if images.attached?
+      if images.length > 10 
+        errors.add(:images, "画像の枚数は最大10枚までです。")
+      end
+      images.each do |image|
+        if !image.content_type.in?(%('image/jpec image/png'))
+          errors.add(:images, "ファイル形式はjpeg, またはpngが使用できます")
+        end
+      end
+    else
+      errors.add(:images, "画像が1枚以上必要です。")
+    end
+  end
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -22,8 +22,9 @@
                 .image-lists
                   %ul.item-image-wrapper.second-image-lists
               = f.label :images, class: "upload-images__container--now-upload" do
+                -# .upload-images__container--now-upload
                 .now-upload-wrapper{"data-total-items": 0}
-                  = f.file_field :images, multiple: true, class: "now-upload-wrapper--input"
+                  = f.file_field :images, multiple: true, class: "now-upload-wrapper--input upload-box-0"
                   %pre.input.upload-images__container--text
                     ドラッグアンドドロップ
                     またはクリックしてファイルをアップロード

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -27,6 +27,7 @@
                   %pre.input.upload-images__container--text
                     ドラッグアンドドロップ
                     またはクリックしてファイルをアップロード
+              .upload-images__container--error-message
 
           .container__form__content.item-about.clearfix
             .form-group

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -6,7 +6,7 @@
       %h2.container__head
         .container__head__title 商品の情報を入力
       
-      = form_with model: @item, local: true do |f|
+      = form_with model: @item, builder: CustomFormBuilder, local: true do |f|
         .container__form
           .container__form__content.upload-images
             %label.upload-images__label
@@ -28,7 +28,8 @@
                   %pre.input.upload-images__container--text
                     ドラッグアンドドロップ
                     またはクリックしてファイルをアップロード
-              .upload-images__container--error-message
+              .upload-images__container--error-message.validate-error-message
+                %p{class: 'error'}=@item.errors.messages[:images][0]
 
           .container__form__content.item-about.clearfix
             .form-group
@@ -37,6 +38,8 @@
                 %span.form-require 
                   必須
               = f.text_field :name, class: "item-about__name--input", placeholder: "商品名（必須 40文字まで)"
+              .validate-error-message
+                %p{class: 'error'}=@item.errors.messages[:name][0]
             .form-group
               %label.item-about__description 
                 商品の説明
@@ -123,16 +126,19 @@
             .selling-item__title.form-sub-title
               販売価格(300〜9,999,999)
             %ul.selling-item__right-box.form-right-box
-              %li.form-group.selling-item__price
-                .selling-item__price__inner-left
-                  %label.selling-item__price--setting
-                    価格
-                    %span.form-require 
-                      必須
-                .selling-item__price__inner-right
-                  ¥
-                  .selling-item__price__inner-right--input
-                    = f.text_field :price, placeholder: "例)  300", id: "selling-item-price"
+              .price-wrapper
+                %li.form-group.selling-item__price
+                  .selling-item__price__inner-left
+                    %label.selling-item__price--setting
+                      価格
+                      %span.form-require 
+                        必須
+                  .selling-item__price__inner-right
+                    ¥
+                    .selling-item__price__inner-right--input
+                      = f.text_field :price, placeholder: "例)  300", id: "selling-item-price"
+                .validate-error-message.selling-item__price__error-message
+                  %p{class: 'error'}=@item.errors.messages[:price][0]
               %li.selling-item__fee.clearfix
                 %p 販売手数料(10%)
                 %p.sale-fee -

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -22,8 +22,8 @@
                 .image-lists
                   %ul.item-image-wrapper.second-image-lists
               = f.label :images, class: "upload-images__container--now-upload" do
-                .now-upload-wrapper
-                  = f.file_field :images, multiple: true, class: "now-upload-wrapper--input", data: {"total-items": 0}
+                .now-upload-wrapper{"data-total-items": 0}
+                  = f.file_field :images, multiple: true, class: "now-upload-wrapper--input"
                   %pre.input.upload-images__container--text
                     ドラッグアンドドロップ
                     またはクリックしてファイルをアップロード

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -2,6 +2,41 @@ ja:
   activerecord:
     models:
       item: 商品
+    
+    attributes:
+      item:
+        images: 画像
+    
+    errors:
+      models:
+        item:
+          attributes:
+            images:
+              blank: "画像がありません"
+            name:
+              blank: "入力してください"
+              too_long: "40文字以下で入力してください"
+            introduction:
+              blank: "入力してください"
+              too_long: "1000文字以下で入力してください"
+            category_id:
+              blank: "選択してください"
+            state:
+              blank: "選択してください"
+            delivery_fee:
+              blank: "選択してください"
+            delivery_method:
+              blank: "選択してください"
+            city:
+              blank: "選択してください"
+            delivery_days:
+              blank: "選択してください"
+            price:
+              not_a_number: "300以上9999999以下で入力してください"
+              greater_than_or_equal_to: "300以上9999999以下で入力してください"
+              less_than_or_equal_to: "300以上9999999以下で入力してください"
+            
+            
   enums:
     item:
       size:


### PR DESCRIPTION
# What
商品出品機能について、以下の機能を実装しました。
- 選択した画像のプレビューが表示されるようにしました。
- 画像の同時に複数選択した際に、正しくプレビューされるようにしました。
- 商品画像（ActiveStorageによるimages）に関するバリデーションを実装しました。
- バリデーションによるエラー発生時（商品名が空欄など）に、各入力フォームの下にエラーメッセージが表示されるようにしました。

# Why
商品出品機能で、実装途中だった部分を完成させるため。

# 備考
- [このプルリクエストに対応するTrelloのカード](https://trello.com/c/NYD3xaWC/15-%E3%80%90%E3%82%B5%E3%83%BC%E3%83%90%E3%82%B5%E3%82%A4%E3%83%89%E3%80%91%E5%95%86%E5%93%81%E5%87%BA%E5%93%81)


# 実装画面・機能のキャプチャ
- [個別にファイルを選択したときの動作（GIF）](https://gyazo.com/78d17c15ee9ee2380654ba6627d848b9)
- [複数の画像を一度に選択したときの動作（GIF）](https://gyazo.com/a6e257e78fa572061ff12681059140d8)
- [バリデーションによるエラーメッセージの表示（GIF) ](https://gyazo.com/21a7db44c393494f417169997223774a)