### PR TITLE
リンク先のURLの記述ミスを修正

### DIFF
--- a/app/views/tops/_item-index.html.haml
+++ b/app/views/tops/_item-index.html.haml
@@ -1,7 +1,7 @@
 .contents__main__center
   .contents__main__center__item
     - items.each do |item|
-      = link_to "/item/#{item.id}/" do
+      = link_to "/items/#{item.id}/" do
         .contents__main__center__item__box
           .contents__main__center__item__box__image
             = image_tag item.images[0].variant(resize: '213x220'), width:"213", height:"220", alt: "イメージ1"


### PR DESCRIPTION
# What
URLのスペルミスを修正。

# Why
商品一覧をクリックしたらitems/show.html.hamlページに遷移できるようにする為。

# 備考
- [このプルリクエストに対応するTrelloのカード](https://trello.com/c/E1R7YuMI/14-%E3%80%90%E3%82%B5%E3%83%BC%E3%83%90%E3%82%B5%E3%82%A4%E3%83%89%E3%80%91%E5%95%86%E5%93%81%E4%B8%80%E8%A6%A7%E8%A1%A8%E7%A4%BA)

# 実装画面・機能のキャプチャ