### PR TITLE
電話番号のテーブルを作成

### DIFF
--- a/app/models/phonenumber.rb
+++ b/app/models/phonenumber.rb
@@ -1,0 +1,2 @@
+class Phonenumber < ApplicationRecord
+end

--- a/db/migrate/20190901035839_create_phonenumbers.rb
+++ b/db/migrate/20190901035839_create_phonenumbers.rb
@@ -1,0 +1,8 @@
+class CreatePhonenumbers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :phonenumbers do |t|
+      t.string :phone_number, null: false, unique: true 
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_25_085606) do
+ActiveRecord::Schema.define(version: 2019_09_01_035839) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -76,6 +76,12 @@ ActiveRecord::Schema.define(version: 2019_08_25_085606) do
     t.index ["name"], name: "index_items_on_name"
   end
 
+  create_table "phonenumbers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "phone_number", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "sns_credentials", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "provider"
     t.string "uid"
@@ -86,22 +92,23 @@ ActiveRecord::Schema.define(version: 2019_08_25_085606) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "nickname", null: false
-    t.string "first_name", null: false
-    t.string "first_name_kana", null: false
-    t.string "last_name", null: false
-    t.string "last_name_kana", null: false
+    t.string "nickname", default: "", null: false
+    t.string "first_name", default: "", null: false
+    t.string "first_name_kana", default: "", null: false
+    t.string "last_name", default: "", null: false
+    t.string "last_name_kana", default: "", null: false
     t.date "birthday"
     t.text "avatar"
     t.text "introduction"
-    t.string "email", null: false
-    t.string "password", null: false
+    t.string "email", default: "", null: false
+    t.string "password", default: "", null: false
     t.integer "phone_number"
-    t.string "reset_password_token"
+    t.string "reset_password_token", default: ""
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "encrypted_password", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/factories/phonenumbers.rb
+++ b/spec/factories/phonenumbers.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :phonenumber do
+    
+  end
+end

--- a/spec/models/phonenumber_spec.rb
+++ b/spec/models/phonenumber_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Phonenumber, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
電話番号だけを登録するテーブルを作成しました。

# Why
ページの遷移毎にテーブルを分けることにより、セキュリティを高めるため。

# 備考
- [このプルリクエストに対応するTrelloのカード](https://trello.com/c/bk5haVag)
電話番号は0から始まることもあり、整数であるintegerが使えないためstring型で作成しています。