### PR TITLE
gem 'faker' バグ修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
+  gem 'faker'
 end
 
 group :development do
@@ -67,7 +68,6 @@ group :test do
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'
-  gem 'faker'
 end
 
 group :production do


### PR DESCRIPTION
# What
gem 'faker' の記述場所を変更しました。

# Why
gem 'faker' がテスト環境に書いてありサーバーが立ち上がらなくなったため、開発環境とテスト環境の両方に記述場所を変更する必要がありました。