### PR TITLE
ユーザー新規登録時のパスワードのバリデーションを変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   validates :email, uniqueness: true
-  validates :password, presence: true, length: { minimum: 7 }, confirmation: true
+  validates :password, presence: true, length: { minimum: 6 }, confirmation: true
 
   with_options presence: true do
     validates :nickname


### PR DESCRIPTION
# What
ユーザー新規登録時のパスワードのバリデーションを変更しました。

# Why
最小値の設定が適切でなかったため。