### PR TITLE
商品出品・編集機能の一部修正

### DIFF
--- a/app/assets/stylesheets/_mixin.scss
+++ b/app/assets/stylesheets/_mixin.scss
@@ -199,3 +199,11 @@
   font-size: 14px;
   margin: 8px 0 0;
 }
+
+@mixin no-transaction-item {
+  padding: 160px 0 60px;
+  background-image: image-url("logo-gray-icon.svg");
+  background-repeat:  no-repeat;
+  background-position: center 40px;
+  background-size: 78px 85px;
+}

--- a/app/assets/stylesheets/users/_exhibiting.scss
+++ b/app/assets/stylesheets/users/_exhibiting.scss
@@ -99,7 +99,13 @@
         }
       }
     }
-
+    &__no-item {
+      @include no-transaction-item;
+      font-weight: bold;
+      text-align: center;
+      font-size: 16px;
+      color: #cccccc;
+    }
   }
   &__pager {
     margin: 40px 0 0;

--- a/app/assets/stylesheets/users/_users.scss
+++ b/app/assets/stylesheets/users/_users.scss
@@ -224,11 +224,7 @@
           color: #cccccc;
           #mypage-tab-transaction-now.mypage-item-list.tab-pane.active {
             .mypage-item-not-found.bold {
-              padding: 160px 0 60px;
-              background-image: image-url("logo-gray-icon.svg");
-              background-repeat:  no-repeat;
-              background-position: center 40px;
-              background-size: 78px 85px;
+              @include no-transaction-item;
             }
           }
         }

--- a/app/views/exhibitions/index.html.haml
+++ b/app/views/exhibitions/index.html.haml
@@ -35,7 +35,7 @@
                   .item-list__arrow
                     %i.fa.fa-chevron-right
           - else
-            取引中の商品がありません
+            .exhibiting-page__content__no-item 取引中の商品がありません
       %ul.exhibiting-page__pager
         %li.exhibiting-page__pager__cell.prev-page
           %i.fa.fa-chevron-left

--- a/app/views/shared/_mypage-leftside.html.haml
+++ b/app/views/shared/_mypage-leftside.html.haml
@@ -17,7 +17,7 @@
         いいね！一覧
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/sell/"}
+      = link_to new_item_path, class: "mypage-leftside__list__item" do
         出品する
         %i.fa.fa-chevron-right
     %li


### PR DESCRIPTION
# What
1.  マイページサイドバーの「出品する」から、出品ページへ飛べるようにリンクを張りました。
2. 「出品した商品 - 出品中」ページで、出品している商品がない場合のビューを修正しました。

# Why
1. linkの貼り漏れがあったため。
2. 商品編集機能作成時に、対応が忘れていたため。

# 実装画面・機能のキャプチャ
1. [出品ページへのリンク(GIF)](https://gyazo.com/73032dfb9690560f688325d8ea361f78)
2. [出品した商品がない場合のビュー](https://gyazo.com/566dee542799cec7757515e909b3c0f5)
