### PR TITLE
N+1問題の解消

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'bullet'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
     bootsnap (1.4.4)
       msgpack (~> 1.0)
     builder (3.2.3)
+    bullet (6.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.0.1)
     capistrano (3.11.0)
       airbrussh (>= 1.0.0)
@@ -359,6 +362,7 @@ GEM
     unicorn (5.4.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    uniform_notifier (1.12.1)
     warden (1.2.8)
       rack (>= 2.0.6)
     web-console (3.7.0)
@@ -382,6 +386,7 @@ DEPENDENCIES
   ancestry
   aws-sdk-s3
   bootsnap (>= 1.1.0)
+  bullet
   byebug
   capistrano
   capistrano-bundler

--- a/app/controllers/exhibitions_controller.rb
+++ b/app/controllers/exhibitions_controller.rb
@@ -2,7 +2,7 @@ class ExhibitionsController < ApplicationController
   before_action :set_item, only: [:show]
 
   def index
-    @selling_items = Item.where(seller_id: current_user.id, status: Item.statuses.values.slice(0)).order("created_at DESC")
+    @selling_items = Item.includes(:images_attachments).where(seller_id: current_user.id, status: Item.statuses.values.slice(0)).order("created_at DESC")
   end
 
   def show

--- a/app/controllers/exhibitions_controller.rb
+++ b/app/controllers/exhibitions_controller.rb
@@ -2,7 +2,7 @@ class ExhibitionsController < ApplicationController
   before_action :set_item, only: [:show]
 
   def index
-    @selling_items = Item.where(seller_id: current_user.id, status: Item.statuses.values.slice(0)).includes(:seller).order("created_at DESC")
+    @selling_items = Item.where(seller_id: current_user.id, status: Item.statuses.values.slice(0)).order("created_at DESC")
   end
 
   def show

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -81,7 +81,7 @@ class ItemsController < ApplicationController
 
   def set_saved_images
     @item_images = @item.images
-    @upper__item_images = @item_images[0..4]
+    @upper_item_images = @item_images[0..4]
     @lower_item_images = @item_images[5..9]
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
   before_action :set_parent_categories, only: [:new, :create, :edit, :update]
-  before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_item, only: [:edit, :update, :destroy]
   before_action :set_saved_images, only: [:edit, :update]
   before_action :set_children_and_grandchildren_categories, only: [:edit, :update]
   before_action :seller_equal_current_user?, only: [:edit, :update]
@@ -10,12 +10,13 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = @item = Item.includes([:images_attachments, images_attachments: :blob]).find(params[:id])
     @randItemLeft = Item.where("id>=?", rand(Item.first.id..Item.last.id)).first
     @randItemRight = Item.where("id>=?", rand(Item.first.id..Item.last.id)).first
     @exhibitor = @item.seller
-    @otherExhibitorItems = @exhibitor.saling_items.where.not(id: @item.id).limit(6).order(created_at: "desc")
+    @otherExhibitorItems = @exhibitor.saling_items.includes([:images_attachments, images_attachments: :blob]).where.not(id: @item.id).limit(6).order(created_at: "desc")
     @category = @item.category
-    @otherCategorysItems = @category.items.where.not(id: @item.id).limit(6).order(created_at: "desc")
+    @otherCategorysItems = @category.items.includes([:images_attachments, images_attachments: :blob]).where.not(id: @item.id).limit(6).order(created_at: "desc")
   end
   
   def new

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -11,6 +11,6 @@ private
   def get_items(id)
     category = Category.find(id)
     categories = category.indirect_ids
-    items = Item.where(category_id: categories).order('id DESC').limit(4)
+    items = Item.includes([:images_attachments, images_attachments: :blob]).where(category_id: categories).order('id DESC').limit(4)
   end
 end

--- a/app/views/items/_sell-form.html.haml
+++ b/app/views/items/_sell-form.html.haml
@@ -11,8 +11,8 @@
         .upload-images__container--uploaded
           .image-lists
             %ul.item-image-wrapper.first-image-lists
-              - if @upper__item_images.present?
-                - @upper__item_images.each.with_index(1) do |image, index|
+              - if @upper_item_images.present?
+                - @upper_item_images.each.with_index(1) do |image, index|
                   %li.image-lists__list
                     .item-image-wrapper__figure
                       = image_tag image, id: "saved-preview-#{index}", alt: "preview-#{index}"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,4 +58,12 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.after_initialize do
+    Bullet.enable = true # Bulletプラグインを有効化
+    Bullet.alert = true # JavaScriptでの通知を設定
+    Bullet.bullet_logger = true # log/bullet.logへの出力
+    Bullet.console = true # ブラウザのコンソールログに記録
+    Bullet.rails_logger = true # Railsログに出力
+  end
 end


### PR DESCRIPTION
# What
各ページで発生していたN+1問題に対応しました。
また、今後N+1問題が発生した際に検出できるように設定しました。

# Why
大量のSQLが発行されることによって、パフォーマンスが低下するのを防ぐため。

# 実装画面・機能のキャプチャ
今回追加したgem 'bullet'で、N+1問題が発生した際に以下のGIFのようなアラートと対策が表示されるようにしています。（開発環境のみ）
- [(GIF)N+1問題の検出](https://gyazo.com/97e8f59de8304a8c91fbe9fcda41af48)

## 参考（実装にあたって参考にした情報など）
#### bulletの使い方について
- [GitHub - flyerhzm/bullet: help to kill N+1 queries and unused eager loading](https://github.com/flyerhzm/bullet)
- [N+1問題を発見しDBのクエリを改善するBullet \| 酒と涙とRubyとRailsと](https://morizyun.github.io/ruby/library-bullet.html)
- [Railsでbulletを使ってN+1問題を発見しDBアクセスのパフォーマンスを向上させる - Rails Webook](https://ruby-rails.hatenadiary.com/entry/20141109/1415522242)

#### N+1問題とincludesについて
- [カリキュラムでの該当箇所 ](https://master.tech-camp.in/curriculums/462#term_364)