### PR TITLE
非ログイン時にアクセスできるページを制限

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
-  
+  before_action :authenticate_user!
 
   private
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, except: [:index, :show]
+  skip_before_action :authenticate_user!, only: [:show]
   before_action :set_parent_categories, only: [:new, :create, :edit, :update]
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :set_saved_images, only: [:edit, :update]

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -1,4 +1,5 @@
 class TopsController < ApplicationController
+  skip_before_action :authenticate_user!, only: [:index]
 
     def index
       @ladyitems = get_items(1)


### PR DESCRIPTION
# What
非ログイン時に、商品一覧（トップページ）と、商品詳細以外のページに行こうとすると、ログインページへリダイレクトされるようにしました。

# Why
上記の2ページ以外の仕様では、ユーザーがログインしていることが必須となるため。

# 備考
- [このプルリクエストに対応するTrelloのカード](https://trello.com/c/BVSZCRh7/38-%E3%82%B5%E3%83%BC%E3%83%90%E3%83%BC%E3%82%B5%E3%82%A4%E3%83%89%E9%A0%BB%E5%87%BA%E3%82%A8%E3%83%A9%E3%83%BC)
（※一番上の項目です。）

# 実装画面・機能のキャプチャ
[(GIF)非ログイン時の動作](https://gyazo.com/03e7081ef0dd7a2b1a03d2f7fd62bcf1)
※以下の順番でキャプチャしています
- 閲覧可能：①一覧ページ → ②詳細ページ
- 閲覧不可：③出品ページ（ログインページへリダイレクト）