### PR TITLE
商品出品・編集機能の一部修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -66,7 +66,7 @@ class ItemsController < ApplicationController
   private
   def item_params
     params.require(:item).permit(
-      :name, :introduction, :category_id, :size, :brand, :state, :delivery_fee, :delivery_method, :city, :delivery_days, :price, images: [], image_ids: []
+      :name, :introduction, :category_id, :size, :brand, :state, :delivery_fee, :delivery_method, :city, :delivery_days, :price, :parent_category, :child_category, images: [], image_ids: []
     ).merge(seller_id: current_user.id, status: 1)
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,6 +2,8 @@ class Item < ApplicationRecord
   belongs_to :category
   has_many_attached :images
   attribute :image_ids
+  attribute :parent_category
+  attribute :child_category
 
   extend ActiveHash::Associations::ActiveRecordExtensions  
   belongs_to_active_hash :prefecture

--- a/app/views/items/_sell-form.html.haml
+++ b/app/views/items/_sell-form.html.haml
@@ -70,14 +70,14 @@
             - if @children_categories.nil?
               .select-wrap
                 %i.fas.fa-angle-down
-                = f.collection_select :category_id, @parent_categories, :id, :name, {prompt: "---"}, {class: "select-wrap__input", id: "parent_category"}
+                = f.collection_select :parent_category, @parent_categories, :id, :name, {prompt: "---"}, {class: "select-wrap__input", id: "parent_category"}
             - else 
               .select-wrap
                 %i.fas.fa-angle-down
-                = f.collection_select :category_id, @parent_categories, :id, :name, {prompt: "---", selected: item.category.root.id}, {class: "select-wrap__input", id: "parent_category"}
+                = f.collection_select :parent_category, @parent_categories, :id, :name, {prompt: "---", selected: item.category.root.id}, {class: "select-wrap__input", id: "parent_category"}
               .select-wrap.child-categories-wrapper
                 %i.fas.fa-angle-down
-                = f.collection_select :category_id, @children_categories, :id, :name, {prompt: "---", selected: item.category.parent.id}, {class: "select-wrap__input", id: "child_category"}
+                = f.collection_select :child_category, @children_categories, :id, :name, {prompt: "---", selected: item.category.parent.id}, {class: "select-wrap__input", id: "child_category"}
               .select-wrap.grandchild-categories-wrapper
                 %i.fas.fa-angle-down
                 = f.collection_select :category_id, @grandchildren_categories, :id, :name, {prompt: "---"}, {class: "select-wrap__input", id: "grandchild_category"}

--- a/app/views/items/_sell-form.html.haml
+++ b/app/views/items/_sell-form.html.haml
@@ -11,7 +11,7 @@
         .upload-images__container--uploaded
           .image-lists
             %ul.item-image-wrapper.first-image-lists
-              - if @upper__item_images.present?
+              - if @upper__item_images.present? # 商品編集時：保存された画像をプレビューで表示
                 - @upper__item_images.each.with_index(1) do |image, index|
                   %li.image-lists__list
                     .item-image-wrapper__figure
@@ -19,9 +19,17 @@
                     .item-image-wrapper__button
                       = link_to "編集", "#"
                       = link_to "削除", "#", class: "delete-saved-image", "data-saved-image-id": image.id
+              - elsif item.images.present? # 商品出品時：バリデーションによりフォームが再表示された際にプレビューを保持
+                - item.images[0..4].each.with_index(1) do |image, index|
+                  %li.image-lists__list
+                    .item-image-wrapper__figure
+                      = image_tag image, id: "preview-#{index}", alt: "preview-#{index}"
+                    .item-image-wrapper__button
+                      = link_to "編集", "#"
+                      = link_to "削除", "#", class: "delete-uploaded-image", "data-image-id": image.id
           .image-lists
             %ul.item-image-wrapper.second-image-lists
-              - if @lower_item_images.present?
+              - if @lower_item_images.present? # 商品編集時：保存された画像をプレビューで表示
                 - @lower_item_images.each.with_index(6) do |image, index|
                   %li.image-lists__list
                     .item-image-wrapper__figure
@@ -29,13 +37,24 @@
                     .item-image-wrapper__button
                       = link_to "編集", "#"
                       = link_to "削除", "#", class: "delete-saved-image", "data-saved-image-id": image.id
+              - elsif item.images[5..9].present? # 商品出品時：バリデーションによりフォームが再表示された際にプレビューを保持
+                - item.images[5..9].each.with_index(6) do |image, index|
+                  %li.image-lists__list
+                    .item-image-wrapper__figure
+                      = image_tag image, id: "preview-#{index}", alt: "preview-#{index}"
+                    .item-image-wrapper__button
+                      = link_to "編集", "#"
+                      = link_to "削除", "#", class: "delete-uploaded-image", "data-image-id": image.id
         = f.label :images, class: "upload-images__container--now-upload" do
           .now-upload-wrapper{"data-total-items": item.images.length}
             = f.file_field :images, multiple: true, class: "now-upload-wrapper--input upload-box-0"
-            - if item.id.present?
+            - if item.id.present? # 商品編集：保存済み画像を削除するための記述
               - @item_images.each.with_index(1) do |image, index|
                 .remove-item-image{style: "display: none;"}
                   = f.check_box :image_ids, {multiple: true, class: "remove-item-image-#{image.id} remove-check-box", checked: false}, image.id, "0"
+            - elsif item.id.nil? && item.images.present?  # 商品出品時：バリデーションによりフォームが再表示された際に、アップロードされたファイルを保持
+              - item.images.each.with_index(1) do |image, index|
+                = f.hidden_field :images, value: image.signed_id, multiple: true, class: "now-upload-wrapper--input upload-box-#{index}"
             %pre.input.upload-images__container--text
               ドラッグアンドドロップ
               またはクリックしてファイルをアップロード

--- a/app/views/items/_sell-form.html.haml
+++ b/app/views/items/_sell-form.html.haml
@@ -82,8 +82,8 @@
                 %i.fas.fa-angle-down
                 = f.collection_select :category_id, @grandchildren_categories, :id, :name, {prompt: "---"}, {class: "select-wrap__input", id: "grandchild_category"}
 
-          -# 出品ページか編集ページかで、「サイズ」・「ブランド」欄の処理を分岐
-          - if item.id.nil?
+          -# 出品ページにアクセスした場合、または孫カテゴリーが選択されていない場合はsizeの入力フォームを出さない
+          - if request.path_info == new_item_path || item.category_id.nil?
             .form-group.select-item-sizes{style: "display: none;"}
               %label.item-detail__category 
                 サイズ
@@ -91,12 +91,12 @@
               .select-wrap
                 %i.fas.fa-angle-down
                 = f.select :size, Item.sizes_i18n.invert, {prompt: "---"}, {class: "select-wrap__input"}
-            .form-group.input-item-brands{style: "display: none;"}
-              %label.item-detail__category 
-                ブランド
-                %span.form-arbitrary 任意
-              .select-wrap
-                = f.text_field :brand, class:"select-wrap__input", placeholder: "例）シャネル"
+              .form-group.input-item-brands{style: "display: none;"}
+                %label.item-detail__category 
+                  ブランド
+                  %span.form-arbitrary 任意
+                .select-wrap
+                  = f.text_field :brand, class:"select-wrap__input", placeholder: "例）シャネル"
           - else 
             .form-group.select-item-sizes
               %label.item-detail__category 


### PR DESCRIPTION
# What
- バリデーションにより商品出品フォームが再表示された場合に、選択済みの画像をプレビューし、選択せずにsubmitできるようにしました。
- 孫カテゴリーを選択しないと、商品の出品・編集ができないように修正しました。

# Why
- 出品フォームに置いてフォームが再表示された際、アップロードした画像が消えてしまっていたため。
- 親カテゴリー、小カテゴリーを選択すると、商品が出品できるようになっていたため。


# 実装画面・機能のキャプチャ
### アップロードした画像に関する処理を修正
- [修正前  :arrow_right: アップロードした画像が消えてしまう](https://gyazo.com/e0a6f7ff6f905700970042a8fa8ebee6)
- [修正後](https://gyazo.com/389403537972eda0d70518774750ad78)

### 孫カテゴリー未選択時の挙動を修正
- [修正前  :arrow_right: 親カテゴリーや小カテゴリだけで出品できてしまう](https://gyazo.com/3368c74b2210f29d69806aac015922c3)
- [修正後](https://gyazo.com/2ff995c6e62bd2ca28915e4a54e107e1)