### PR TITLE
マイページサイドバーのリンクを修正

### DIFF
--- a/app/views/shared/_mypage-leftside.html.haml
+++ b/app/views/shared/_mypage-leftside.html.haml
@@ -5,15 +5,15 @@
         マイページ
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/notification/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         お知らせ
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/todo/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         やることリスト
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/like/history/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         いいね！一覧
         %i.fa.fa-chevron-right
     %li
@@ -25,46 +25,46 @@
         出品した商品 - 出品中
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/listings/in_progress/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         出品した商品 - 取引中
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/listings/completed/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         出品した商品 - 売却済み
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/purchase/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         購入した商品 - 取引中
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/purchased/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         購入した商品 - 過去の取引
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/news/"}
+      = link_to "#", class: "mypage-leftside__list__item" do      
         ニュース一覧
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/review/history/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         評価一覧
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/help_center/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         ガイド
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/support/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         お問い合わせ
         %i.fa.fa-chevron-right
 
   %h3.mypage-nav-head メルペイ
   %ul.mypage-leftside__list
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/sales/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         売上・振込申請
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/point/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         ポイント
         %i.fa.fa-chevron-right
         
@@ -75,7 +75,7 @@
         プロフィール
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/deliver_address/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         発送元・お届け先住所変更
         %i.fa.fa-chevron-right
     %li
@@ -83,7 +83,7 @@
         支払い方法
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/email_password/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         メール/パスワード
         %i.fa.fa-chevron-right
     %li
@@ -91,7 +91,7 @@
         本人情報
         %i.fa.fa-chevron-right
     %li
-      %a.mypage-leftside__list__item{href: "/jp/mypage/sms_confirmation/"}
+      = link_to "#", class: "mypage-leftside__list__item" do
         電話番号の確認
         %i.fa.fa-chevron-right
     %li


### PR DESCRIPTION
# What
マイページサイドバーのリンクを修正しました。

# Why
クローンサイトで使用しないページについて、メルカリのURL（相対パス）を指定しており、クリックするとエラーが発生する状態であったため。

# 備考
マイページについて、以下の通りいくつか修正が必要な箇所が残っています。
お手数ですが、ブランチを切って修正をお願いいたします。
- [マイページトップ(キャプチャ)](https://gyazo.com/4fe6a620be30a6c4672c6fecef1230ec) →ログインしているユーザーのニックネームを出すようにしましょう。また、クリックすると、実際のメルカリのページに飛んでしまうので、リンクを無効にしましょう。
- [プロフィールページ(キャプチャ)](https://gyazo.com/069d6e2852255f7ae6967fa6aee760c7) → ログインしているユーザーのニックネームを出すようにしましょう。
- 本人情報ページ → 現在ログインしているユーザーの情報を出すようにしましょう。