### PR TITLE
商品検索時のアイテム表示の追加実装

### DIFF
--- a/app/assets/stylesheets/items/_search.scss
+++ b/app/assets/stylesheets/items/_search.scss
@@ -1,6 +1,5 @@
 .search{
   font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
-  font-size: 14px;
   color: #333;
   background: #f5f5f5;
   line-height: 1;

--- a/app/assets/stylesheets/items/_search.scss
+++ b/app/assets/stylesheets/items/_search.scss
@@ -33,6 +33,9 @@
             margin: 4px 0 4px;
           }
         }
+        p{
+          margin: 16px 0 40px;
+        }
         &__result-number{
           height: 12px;
           margin: 16px 0;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -60,6 +60,7 @@ class ItemsController < ApplicationController
     @value = params[:search]
     if @value.present?
       @search = Item.includes([:images_attachments, images_attachments: :blob]).where("name LIKE?", "%#{@value}%")
+      @new_items = Item.includes([:images_attachments, images_attachments: :blob]).order('id DESC')
     else
       @search = Item.includes([:images_attachments, images_attachments: :blob]).order('id DESC')
     end

--- a/app/views/items/_search-items.html.haml
+++ b/app/views/items/_search-items.html.haml
@@ -1,0 +1,15 @@
+.search__main__right__item-container__items-list.clearfix
+  - search.each do |item|
+    %section.search__main__right__item-container__items-list__item-box
+      = link_to item_path(item) do
+        %figure.search__main__right__item-container__items-list__item-box__photo
+          = image_tag item.images[0], width: "160", height: "160"
+        .search__main__right__item-container__items-list__item-box__body
+          %h3.search__main__right__item-container__items-list__item-box__body--name 
+            = item.name
+          .search__main__right__item-container__items-list__item-box__body__num
+            .search__main__right__item-container__items-list__item-box__body__num__price 
+              = "¥ #{item.price.to_s(:delimited)}"
+            .search__main__right__item-container__items-list__item-box__body__num__heart-icon
+              %i.far.fa-heart
+              %span 6

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -4,12 +4,17 @@
     -# 右側部分
     .search__main__right
       %section.search__main__right__item-container
-        - if @value.present?
+        - if @value.present? && @search.length > 0
           .search__main__right__item-container__search-text
             %h2.search__main__right__item-container__search-text--text= @value
             %span の検索結果
           .search__main__right__item-container__result-number
             = "1 - #{@search.length}件表示"
+        - elsif @search.length == 0
+          .search__main__right__item-container__search-text
+            %h2.search__main__right__item-container__search-text--text= @value
+            %span の検索結果
+          %p 該当する商品が見つかりません。検索条件を変えて、再度お試しください。
         - else
           .search__main__right__item-container__search-text
             %h2.search__main__right__item-container__search-text--text 新着商品

--- a/app/views/items/search.html.haml
+++ b/app/views/items/search.html.haml
@@ -15,24 +15,15 @@
             %h2.search__main__right__item-container__search-text--text= @value
             %span の検索結果
           %p 該当する商品が見つかりません。検索条件を変えて、再度お試しください。
+          .search__main__right__item-container__search-text
+            %h2.search__main__right__item-container__search-text--text 新着商品
         - else
           .search__main__right__item-container__search-text
             %h2.search__main__right__item-container__search-text--text 新着商品
-        .search__main__right__item-container__items-list.clearfix
-          - @search.each do |item|
-            %section.search__main__right__item-container__items-list__item-box
-              = link_to item_path(item) do
-                %figure.search__main__right__item-container__items-list__item-box__photo
-                  = image_tag item.images[0], width: "160", height: "160"
-                .search__main__right__item-container__items-list__item-box__body
-                  %h3.search__main__right__item-container__items-list__item-box__body--name 
-                    = item.name
-                  .search__main__right__item-container__items-list__item-box__body__num
-                    .search__main__right__item-container__items-list__item-box__body__num__price 
-                      = "¥ #{item.price.to_s(:delimited)}"
-                    .search__main__right__item-container__items-list__item-box__body__num__heart-icon
-                      %i.far.fa-heart
-                      %span 6
+        - if @search.length > 0
+          = render partial: "search-items", locals: {search: @search}
+        - else @search.length == 0
+          = render partial: "search-items", locals: {search: @new_items}
       %ul.search__main__right__item-pagenation
         %li.search__main__right__item-pagenation__num
           %ul


### PR DESCRIPTION
# What
商品検索時の出品アイテム表示の追加処理。
・検索商品がなかった場合の表示を追加しました。

# Why
検索結果がマッチしなかった場合、ユーザーに新着アイテムを表示し購買意欲を高める為。

# 備考
- [このプルリクエストに対応するTrelloのカード](リンクをここに貼ってください)

# 実装画面・機能のキャプチャ
- [検索商品がなかった場合](https://i.gyazo.com/e854019a43764c29ac8eabb2715c9acc.mp4)