### PR TITLE
カテゴリー検索機能の修正

### DIFF
--- a/app/assets/stylesheets/modules/_top-header.scss
+++ b/app/assets/stylesheets/modules/_top-header.scss
@@ -112,7 +112,7 @@
             list-style: none;
             font-size: 14px;
             width: 224px;
-            z-index: 1;
+            z-index: 10;
             position: absolute;
             .parent-category-list {
               width: 224px;


### PR DESCRIPTION
# What
親カテゴリーのz-indexを修正いたしました。

# Why
本番環境にで親カテゴリーが前面に出ないといけないところを、背面に出ていたため。

# 備考
- [このプルリクエストに対応するTrelloのカード](https://trello.com/c/yyqszR1Z)

# 実装画面・機能のキャプチャ
https://gyazo.com/d8a79ea0ba1818f17032268c6ca8357b