### PR TITLE
bodyにmin-widthの値を設定

### DIFF
--- a/app/assets/stylesheets/_reset.scss
+++ b/app/assets/stylesheets/_reset.scss
@@ -19,7 +19,11 @@ html{
     TODO test putting a class on HEAD.
         - Fails on FF.
 */
-body,
+body {
+    margin:0;
+    padding:0;
+    min-width: 1080px;
+}
 div,
 dl,
 dt,


### PR DESCRIPTION
# What
bodyにmin-widthの値を設定しました。

# Why
ウィンドウの横幅が、ヘッダー・フッターよりも狭かった場合に、コンテンツ部分が途切れてしまう現象が発生していたため。

### 例
- [トップページ](https://gyazo.com/67b896a3164f5d6bca0c0d24d874a8d1)
- [マイページ](https://gyazo.com/55b8fa3b542a1717e33e64f9d3ffb370)
- [商品検索ページ](https://gyazo.com/678341911c23eaacac7b408a24fbabf7)

# How
bodyの最小幅をヘッダー・フッターと同じ幅にすることで、上記の現象が起きないようにしました。
